### PR TITLE
fix: recuperar CSRF em 403 e corrigir date no Safari iOS

### DIFF
--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -1,10 +1,18 @@
 import { TestBed } from '@angular/core/testing';
+
 import { App } from './app';
+import { SessionResumeService } from './core/services/session-resume.service';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [
+        {
+          provide: SessionResumeService,
+          useValue: { start: () => undefined },
+        },
+      ],
     }).compileComponents();
   });
 

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
+import { SessionResumeService } from './core/services/session-resume.service';
 import { AppToastComponent } from './shared/components/app-toast/app-toast.component';
 import { ConfirmDialogComponent } from './shared/components/confirm-dialog/confirm-dialog.component';
 
@@ -9,4 +10,8 @@ import { ConfirmDialogComponent } from './shared/components/confirm-dialog/confi
   imports: [RouterOutlet, AppToastComponent, ConfirmDialogComponent],
   templateUrl: './app.html',
 })
-export class App {}
+export class App {
+  constructor() {
+    inject(SessionResumeService).start();
+  }
+}

--- a/frontend/src/app/core/interceptors/auth-refresh.interceptor.spec.ts
+++ b/frontend/src/app/core/interceptors/auth-refresh.interceptor.spec.ts
@@ -1,0 +1,134 @@
+import { HttpClient, HttpErrorResponse, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+
+import { CsrfTokenService } from '../services/csrf-token.service';
+import { RawHttpService } from '../services/raw-http.service';
+import { SessionService } from '../services/session.service';
+import {
+  authRefreshInterceptor,
+  CSRF_RECOVERY_ATTEMPTED,
+  resetAuthRefreshStateForTests,
+} from './auth-refresh.interceptor';
+
+describe('authRefreshInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let csrfTokenService: CsrfTokenService;
+  let session: { clearSession: ReturnType<typeof vi.fn> };
+  let router: Router;
+
+  beforeEach(() => {
+    resetAuthRefreshStateForTests();
+    session = { clearSession: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        provideHttpClient(withInterceptors([authRefreshInterceptor])),
+        provideHttpClientTesting(),
+        {
+          provide: SessionService,
+          useValue: session,
+        },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    csrfTokenService = TestBed.inject(CsrfTokenService);
+    router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    csrfTokenService.invalidate();
+    resetAuthRefreshStateForTests();
+  });
+
+  it('em 403 invalida CSRF, busca token novo e retenta com header atualizado', async () => {
+    const invalidateSpy = vi.spyOn(csrfTokenService, 'invalidate');
+    const requestPromise = firstValueFrom(
+      http.post('/api/categorias', { nome: 'Moradia' }, {
+        headers: { 'X-XSRF-TOKEN': 'token-antigo' },
+      })
+    );
+
+    const first = httpMock.expectOne('/api/categorias');
+    expect(first.request.headers.get('X-XSRF-TOKEN')).toBe('token-antigo');
+    first.flush({ error: 'Forbidden' }, { status: 403, statusText: 'Forbidden' });
+
+    const csrfReq = httpMock.expectOne('/api/auth/csrf');
+    csrfReq.flush({ token: 'token-novo', headerName: 'X-XSRF-TOKEN' });
+
+    const retry = httpMock.expectOne('/api/categorias');
+    expect(retry.request.headers.get('X-XSRF-TOKEN')).toBe('token-novo');
+    expect(retry.request.context.get(CSRF_RECOVERY_ATTEMPTED)).toBe(true);
+    retry.flush({ id: 1 });
+
+    await expect(requestPromise).resolves.toEqual({ id: 1 });
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it('em 403 no retry propaga o erro sem loop', async () => {
+    const requestPromise = firstValueFrom(
+      http.post('/api/categorias', {}, { headers: { 'X-XSRF-TOKEN': 'token-antigo' } })
+    ).catch((error: unknown) => error);
+
+    httpMock.expectOne('/api/categorias').flush(null, { status: 403, statusText: 'Forbidden' });
+    httpMock.expectOne('/api/auth/csrf').flush({ token: 'token-novo', headerName: 'X-XSRF-TOKEN' });
+
+    const retry = httpMock.expectOne('/api/categorias');
+    expect(retry.request.context.get(CSRF_RECOVERY_ATTEMPTED)).toBe(true);
+    retry.flush(null, { status: 403, statusText: 'Forbidden' });
+
+    const error = (await requestPromise) as HttpErrorResponse;
+    expect(error).toBeInstanceOf(HttpErrorResponse);
+    expect(error.status).toBe(403);
+    httpMock.expectNone('/api/auth/csrf');
+  });
+
+  it('em 401 invalida CSRF, faz refresh e retenta com header fresco', async () => {
+    const invalidateSpy = vi.spyOn(csrfTokenService, 'invalidate');
+    const requestPromise = firstValueFrom(
+      http.post('/api/categorias', {}, { headers: { 'X-XSRF-TOKEN': 'token-antigo' } })
+    );
+
+    httpMock.expectOne('/api/categorias').flush(null, { status: 401, statusText: 'Unauthorized' });
+
+    httpMock.expectOne('/api/auth/csrf').flush({ token: 'csrf-refresh', headerName: 'X-XSRF-TOKEN' });
+
+    const refresh = httpMock.expectOne('/api/auth/refresh');
+    expect(refresh.request.headers.get('X-XSRF-TOKEN')).toBe('csrf-refresh');
+    refresh.flush(null);
+
+    httpMock.expectOne('/api/auth/csrf').flush({ token: 'csrf-pos-refresh', headerName: 'X-XSRF-TOKEN' });
+
+    const retry = httpMock.expectOne('/api/categorias');
+    expect(retry.request.headers.get('X-XSRF-TOKEN')).toBe('csrf-pos-refresh');
+    retry.flush({ id: 2 });
+
+    await expect(requestPromise).resolves.toEqual({ id: 2 });
+    expect(invalidateSpy).toHaveBeenCalled();
+    expect(session.clearSession).not.toHaveBeenCalled();
+  });
+
+  it('quando o refresh falha limpa a sessao e navega para login', async () => {
+    const requestPromise = firstValueFrom(http.get('/api/auth/me')).catch((error: unknown) => error);
+
+    httpMock.expectOne('/api/auth/me').flush(null, { status: 401, statusText: 'Unauthorized' });
+    httpMock.expectOne('/api/auth/csrf').flush({ token: 'csrf', headerName: 'X-XSRF-TOKEN' });
+    httpMock.expectOne('/api/auth/refresh').flush(
+      { error: 'Refresh token inválido' },
+      { status: 401, statusText: 'Unauthorized' }
+    );
+
+    const error = (await requestPromise) as HttpErrorResponse;
+    expect(error.status).toBe(401);
+    expect(session.clearSession).toHaveBeenCalledTimes(1);
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/frontend/src/app/core/interceptors/auth-refresh.interceptor.ts
+++ b/frontend/src/app/core/interceptors/auth-refresh.interceptor.ts
@@ -1,17 +1,31 @@
-import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import {
+  HttpContextToken,
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandlerFn,
+  HttpInterceptorFn,
+  HttpRequest,
+} from '@angular/common/http';
 import { inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { catchError, finalize, Observable, shareReplay, switchMap, throwError } from 'rxjs';
 
 import { API_BASE_URL } from '../config/api.config';
-import { RawHttpService } from '../services/raw-http.service';
 import { CsrfTokenService } from '../services/csrf-token.service';
+import { RawHttpService } from '../services/raw-http.service';
 import { SessionService } from '../services/session.service';
 
 const AUTH_ROUTES_WITHOUT_REFRESH = ['/api/auth/login', '/api/auth/register', '/api/auth/refresh'];
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 const UNAUTHORIZED_STATUS = 401;
+const FORBIDDEN_STATUS = 403;
+export const CSRF_RECOVERY_ATTEMPTED = new HttpContextToken<boolean>(() => false);
 
 let refreshInFlight$: Observable<void> | null = null;
+
+export function resetAuthRefreshStateForTests(): void {
+  refreshInFlight$ = null;
+}
 
 export const authRefreshInterceptor: HttpInterceptorFn = (req, next) => {
   const rawHttp = inject(RawHttpService);
@@ -21,45 +35,107 @@ export const authRefreshInterceptor: HttpInterceptorFn = (req, next) => {
 
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
-      const isUnauthorized = error.status === UNAUTHORIZED_STATUS;
-      const shouldSkipRefresh = AUTH_ROUTES_WITHOUT_REFRESH.some((route) => req.url.includes(route));
+      const shouldSkipAuthRoutes = AUTH_ROUTES_WITHOUT_REFRESH.some((route) => req.url.includes(route));
 
-      if (!isUnauthorized || shouldSkipRefresh) {
-        return throwError(() => error);
-      }
+      if (
+        error.status === FORBIDDEN_STATUS &&
+        !shouldSkipAuthRoutes &&
+        MUTATING_METHODS.has(req.method)
+      ) {
+        if (req.context.get(CSRF_RECOVERY_ATTEMPTED)) {
+          return throwError(() => error);
+        }
 
-      if (!refreshInFlight$) {
-        refreshInFlight$ = csrfTokenService.getToken().pipe(
-          switchMap(({ headerName, token }) =>
-            rawHttp.http.post<void>(
-              `${API_BASE_URL}/api/auth/refresh`,
-              {},
-              {
-                withCredentials: true,
-                headers: { [headerName]: token },
-              }
-            )
-          ),
-            shareReplay(1),
-            finalize(() => {
-              refreshInFlight$ = null;
-            })
+        return retryWithFreshCsrf(req, next, csrfTokenService).pipe(
+          catchError((retryError: HttpErrorResponse) => {
+            if (retryError.status === UNAUTHORIZED_STATUS && !shouldSkipAuthRoutes) {
+              return refreshAndRetry(req, next, rawHttp, csrfTokenService, session, router);
+            }
+
+            return throwError(() => retryError);
+          })
         );
       }
 
-      return refreshInFlight$.pipe(
-        switchMap(() => next(req)),
-        catchError((refreshError) => {
-          session.clearSession();
+      if (error.status !== UNAUTHORIZED_STATUS || shouldSkipAuthRoutes) {
+        return throwError(() => error);
+      }
 
-          const isAuthScreen = router.url.startsWith('/login') || router.url.startsWith('/cadastro');
-          if (!isAuthScreen) {
-            router.navigate(['/login']);
-          }
-
-          return throwError(() => refreshError);
-        })
-      );
+      return refreshAndRetry(req, next, rawHttp, csrfTokenService, session, router);
     })
   );
 };
+
+function retryWithFreshCsrf(
+  req: HttpRequest<unknown>,
+  next: HttpHandlerFn,
+  csrfTokenService: CsrfTokenService
+): Observable<HttpEvent<unknown>> {
+  csrfTokenService.invalidate();
+
+  return csrfTokenService.getToken().pipe(
+    switchMap(({ headerName, token }) =>
+      next(
+        req.clone({
+          headers: req.headers.set(headerName, token),
+          context: req.context.set(CSRF_RECOVERY_ATTEMPTED, true),
+        })
+      )
+    )
+  );
+}
+
+function refreshAndRetry(
+  req: HttpRequest<unknown>,
+  next: HttpHandlerFn,
+  rawHttp: RawHttpService,
+  csrfTokenService: CsrfTokenService,
+  session: SessionService,
+  router: Router
+): Observable<HttpEvent<unknown>> {
+  if (!refreshInFlight$) {
+    csrfTokenService.invalidate();
+    refreshInFlight$ = csrfTokenService.getToken().pipe(
+      switchMap(({ headerName, token }) =>
+        rawHttp.http.post<void>(`${API_BASE_URL}/api/auth/refresh`, {}, {
+          withCredentials: true,
+          headers: { [headerName]: token },
+        })
+      ),
+      shareReplay(1),
+      finalize(() => {
+        refreshInFlight$ = null;
+      })
+    );
+  }
+
+  return refreshInFlight$.pipe(
+    switchMap(() => {
+      csrfTokenService.invalidate();
+
+      if (!MUTATING_METHODS.has(req.method)) {
+        return next(req);
+      }
+
+      return csrfTokenService.getToken().pipe(
+        switchMap(({ headerName, token }) =>
+          next(
+            req.clone({
+              headers: req.headers.set(headerName, token),
+            })
+          )
+        )
+      );
+    }),
+    catchError((refreshError) => {
+      session.clearSession();
+
+      const isAuthScreen = router.url.startsWith('/login') || router.url.startsWith('/cadastro');
+      if (!isAuthScreen) {
+        router.navigate(['/login']);
+      }
+
+      return throwError(() => refreshError);
+    })
+  );
+}

--- a/frontend/src/app/core/interceptors/global-error.interceptor.ts
+++ b/frontend/src/app/core/interceptors/global-error.interceptor.ts
@@ -48,6 +48,10 @@ function mapHttpErrorToMessage(error: HttpErrorResponse): string {
     return 'Sessão expirada. Faça login novamente.';
   }
 
+  if (error.status === 403) {
+    return 'Não autorizado. Tente novamente.';
+  }
+
   return 'Não foi possível concluir a requisição.';
 }
 

--- a/frontend/src/app/core/services/session-resume.service.spec.ts
+++ b/frontend/src/app/core/services/session-resume.service.spec.ts
@@ -1,0 +1,62 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { CsrfTokenService } from './csrf-token.service';
+import { SessionResumeService } from './session-resume.service';
+import { SessionService } from './session.service';
+
+describe('SessionResumeService', () => {
+  let csrfTokenService: { invalidate: ReturnType<typeof vi.fn> };
+  let session: {
+    isAuthenticated: ReturnType<typeof vi.fn>;
+    bootstrapSession: ReturnType<typeof vi.fn>;
+  };
+  let service: SessionResumeService;
+
+  beforeEach(() => {
+    csrfTokenService = { invalidate: vi.fn() };
+    session = {
+      isAuthenticated: vi.fn(() => false),
+      bootstrapSession: vi.fn(() => of(true)),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        SessionResumeService,
+        { provide: CsrfTokenService, useValue: csrfTokenService },
+        { provide: SessionService, useValue: session },
+      ],
+    });
+
+    service = TestBed.inject(SessionResumeService);
+  });
+
+  it('invalida CSRF ao retomar', () => {
+    service.onResume();
+
+    expect(csrfTokenService.invalidate).toHaveBeenCalledTimes(1);
+    expect(session.bootstrapSession).not.toHaveBeenCalled();
+  });
+
+  it('revalida a sessao quando ja autenticado em memoria', () => {
+    session.isAuthenticated.mockReturnValue(true);
+
+    service.onResume();
+
+    expect(csrfTokenService.invalidate).toHaveBeenCalledTimes(1);
+    expect(session.bootstrapSession).toHaveBeenCalledWith(true);
+  });
+
+  it('invalida CSRF quando a aba volta a ficar visivel', () => {
+    service.start();
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(csrfTokenService.invalidate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/core/services/session-resume.service.ts
+++ b/frontend/src/app/core/services/session-resume.service.ts
@@ -1,0 +1,41 @@
+import { inject, Injectable } from '@angular/core';
+
+import { CsrfTokenService } from './csrf-token.service';
+import { SessionService } from './session.service';
+
+/**
+ * Invalida o cache CSRF ao retomar o app (PWA / aba em background),
+ * evitando 403 por token desalinhado do cookie após idle longo.
+ */
+@Injectable({ providedIn: 'root' })
+export class SessionResumeService {
+  private readonly csrfTokenService = inject(CsrfTokenService);
+  private readonly session = inject(SessionService);
+  private started = false;
+
+  start(): void {
+    if (this.started || typeof document === 'undefined') {
+      return;
+    }
+
+    this.started = true;
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        this.onResume();
+      }
+    });
+
+    window.addEventListener('pageshow', () => {
+      this.onResume();
+    });
+  }
+
+  onResume(): void {
+    this.csrfTokenService.invalidate();
+
+    if (this.session.isAuthenticated()) {
+      this.session.bootstrapSession(true).subscribe();
+    }
+  }
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -289,10 +289,33 @@ select optgroup {
 
 .bf-input[type='date'],
 .bf-input[type='month'] {
+	display: block;
 	width: 100%;
 	max-width: 100%;
 	min-width: 0;
 	box-sizing: border-box;
+	overflow: hidden;
+	-webkit-appearance: none;
+	appearance: none;
+}
+
+/* Safari iOS: partes internas do date têm min-content que estoura o container */
+.bf-input[type='date']::-webkit-datetime-edit,
+.bf-input[type='month']::-webkit-datetime-edit,
+.bf-input[type='date']::-webkit-datetime-edit-fields-wrapper,
+.bf-input[type='month']::-webkit-datetime-edit-fields-wrapper,
+.bf-input[type='date']::-webkit-datetime-edit-text,
+.bf-input[type='month']::-webkit-datetime-edit-text {
+	min-width: 0;
+	max-width: 100%;
+	overflow: hidden;
+}
+
+.bf-input[type='date']::-webkit-date-and-time-value,
+.bf-input[type='month']::-webkit-date-and-time-value {
+	min-width: 0;
+	max-width: 100%;
+	text-align: left;
 }
 
 .bf-input[type='date']::-webkit-calendar-picker-indicator,
@@ -301,6 +324,7 @@ select optgroup {
 	opacity: 1;
 	width: 1.1rem;
 	height: 1.1rem;
+	flex-shrink: 0;
 }
 
 :root[data-theme='light'] .bf-input[type='date'],
@@ -329,8 +353,24 @@ select optgroup {
 	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23162118' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='18' height='18' rx='2'/%3E%3Cline x1='16' y1='2' x2='16' y2='6'/%3E%3Cline x1='8' y1='2' x2='8' y2='6'/%3E%3Cline x1='3' y1='10' x2='21' y2='10'/%3E%3C/svg%3E");
 }
 
+.modal-card form {
+	min-width: 0;
+	width: 100%;
+}
+
+.modal-card form.grid {
+	grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 768px) {
+	.modal-card form.grid[class*='md:grid-cols-12'] {
+		grid-template-columns: repeat(12, minmax(0, 1fr));
+	}
+}
+
 .modal-card .bf-label {
 	min-width: 0;
+	max-width: 100%;
 }
 
 .modal-backdrop-nested {


### PR DESCRIPTION
## Summary
- Recupera CSRF em mutações com 403 (token desalinhado), com retry único e refresh de sessão quando necessário; invalida o cache CSRF ao retomar a aba/PWA.
- Corrige overflow dos inputs `date`/`month` em modais no Safari iOS.
- Cobre o fluxo com testes do interceptor, `SessionResumeService` e ajuste no `App`.

## Test plan
- [ ] Abrir o app, deixar a aba em background por um tempo e tentar criar/editar (POST/PUT) — não deve falhar com 403 por CSRF stale
- [ ] Forçar sessão expirada e confirmar redirect para `/login` após falha no refresh
- [ ] No Safari iOS, abrir modal com campo de data/mês e confirmar que o input não estoura o layout
- [ ] Rodar testes unitários relevantes (`auth-refresh`, `session-resume`, `app`)