### PR TITLE
fix(dashboard): unifica gráfico de categorias e tooltips em R$ (#18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+BudgetFlow is a personal-finance app: an Angular 21 SPA in `frontend/` and a Spring Boot 4 / Java 21 REST API in `backend/`, backed by PostgreSQL 16. Standard commands are documented in `README.md`; only the non-obvious cloud caveats are captured here.
+
+### Services and how to run them (start these each session; they are NOT in the update script)
+
+The update script only refreshes dependencies. On a fresh VM you must start the infra + services yourself:
+
+1. **PostgreSQL 16** (installed natively, not via Docker for the app): start with
+   `sudo pg_ctlcluster 16 main start`. The `budgetflow` database and the `postgres`/`postgres` credentials already exist in the snapshot. Recreate if missing:
+   `sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"` and
+   `sudo -u postgres psql -c "CREATE DATABASE budgetflow;"`.
+2. **Backend API** (`:8080`) from `backend/`. Do NOT use the default `dev` Docker-Compose Postgres; point Spring at the native DB and disable compose:
+   ```bash
+   cd backend
+   SPRING_PROFILES_ACTIVE=dev SPRING_DOCKER_COMPOSE_ENABLED=false \
+   SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/budgetflow \
+   SPRING_DATASOURCE_USERNAME=postgres SPRING_DATASOURCE_PASSWORD=postgres \
+   JWT_SECRET=dev-only-change-me-with-at-least-32-chars FRONTEND_URL=http://localhost:4200 \
+   ./mvnw spring-boot:run
+   ```
+   Liquibase migrations run automatically on startup.
+3. **Frontend dev server** (`:4200`) from `frontend/`: `npm start`. It proxies `/api`, `/oauth2`, `/login/oauth2` to `127.0.0.1:8080` (see `frontend/proxy.conf.json`).
+
+### Critical gotcha: `frontend/public/app-config.json` points at production
+
+The committed `frontend/public/app-config.json` has `"apiBaseUrl": "https://api.budgetflow.site"`. With that value the SPA calls the **production** API instead of the local backend (registration/login appear to fail locally with "Falha na requisição"). For local dev this file must be `{"apiBaseUrl": ""}` so the app uses the Angular proxy (as documented in `README.md`). Keep this as a local (uncommitted) change so the production frontend config is not altered.
+
+### Email verification is required for password login, and Resend is not configured
+
+Email/password login is blocked until `users.email_verified_at` is set, and no `RESEND_API_KEY` is present, so verification emails are never sent. To unblock a test account after registering, set it directly in the DB:
+`UPDATE users SET email_verified_at = NOW() WHERE email='<email>';`
+Passwords must contain uppercase, lowercase, a digit and a special character (e.g. `SenhaForte123!`). Google OAuth login needs real Google credentials and is optional.
+
+### Tests
+
+- Backend: `cd backend && ./mvnw test` — uses Testcontainers, so the Docker daemon must be running (`sudo dockerd &`). The `postgres:16` image is already pulled in the snapshot. The current user is in the `docker` group but the daemon must be started each session.
+- Frontend: `cd frontend && npx ng test --watch=false` (Vitest). There is no dedicated lint step in the repo.

--- a/frontend/src/app/features/dashboard/components/dashboard-planejamento-comparativo/dashboard-planejamento-comparativo.component.ts
+++ b/frontend/src/app/features/dashboard/components/dashboard-planejamento-comparativo/dashboard-planejamento-comparativo.component.ts
@@ -6,6 +6,7 @@ import { NgChartsModule } from 'ng2-charts';
 import { PlanejamentoResponse } from '../../../../core/models/planejamento.models';
 import { TransacaoResponse } from '../../../../core/models/transacao.models';
 import { ThemeService } from '../../../../core/services/theme.service';
+import { currencyTooltipLabel } from '../../../../shared/utils/chart-tooltip.util';
 import {
   buildCategoriaComparativoChartData,
   buildComparativoPlanejamento,
@@ -43,6 +44,10 @@ export class DashboardPlanejamentoComparativoComponent {
       maintainAspectRatio: false,
       plugins: {
         legend: { position: 'bottom', labels: { color: this.cssVar('--muted-text') } },
+        tooltip: {
+          enabled: true,
+          callbacks: { label: currencyTooltipLabel },
+        },
         datalabels: { display: false },
       },
       scales: {

--- a/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.html
+++ b/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.html
@@ -13,28 +13,18 @@
     @if (resumoCategorias().length === 0) {
       <p class="muted">Sem despesas no período selecionado.</p>
     } @else {
-      <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-        @for (item of resumoCategorias(); track item.nome + item.classificacao) {
-          <article class="categoria-card">
-            <header>
-              <div>
-                <strong>{{ item.nome }}</strong>
-                <small>{{ classificacaoLabels[item.classificacao] }}</small>
-              </div>
-              <span>{{ item.total | currencyBRL }}</span>
-            </header>
-            <div class="categoria-chart">
-              <canvas
-                baseChart
-                [type]="categoriaChartType"
-                [data]="categoriaChartData(item)"
-                [options]="categoriaChartOptions()"
-              ></canvas>
-              <span class="categoria-percent flex items-center justify-center">{{ item.percentualLucro | number: '1.0-0' }}%</span>
-            </div>
-            <small>Percentual do lucro gasto</small>
-          </article>
-        }
+      <div class="chart-block">
+        <div class="chart-head">
+          <h3>Gastos por categoria</h3>
+        </div>
+        <div class="categorias-chart">
+          <canvas
+            baseChart
+            [type]="doughnutChartType"
+            [data]="categoriasChartData()"
+            [options]="categoriasChartOptions()"
+          ></canvas>
+        </div>
       </div>
     }
 

--- a/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.html
+++ b/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.html
@@ -31,14 +31,6 @@
     <div class="chart-block">
       <div class="chart-head">
         <h3>Gastos por dia</h3>
-        <div class="legend">
-          @for (item of categoriasLegenda(); track item.nome) {
-            <span class="legend-item">
-              <i [style.background]="item.color"></i>
-              {{ item.nome }}
-            </span>
-          }
-        </div>
       </div>
       <div class="daily-chart">
         <canvas
@@ -47,6 +39,14 @@
           [data]="dailyChartData()"
           [options]="dailyChartOptions()"
         ></canvas>
+      </div>
+      <div class="legend">
+        @for (item of categoriasLegenda(); track item.nome) {
+          <span class="legend-item">
+            <i [style.background]="item.color"></i>
+            {{ item.nome }}
+          </span>
+        }
       </div>
     </div>
 

--- a/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.scss
+++ b/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.scss
@@ -32,58 +32,9 @@
   cursor: pointer;
 }
 
-.categoria-card {
-  border: 1px solid var(--row-line);
-  border-radius: 0.9rem;
-  padding: 0.75rem;
-  background: var(--surface-1);
-
-  header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.8rem;
-  }
-
-  strong {
-    display: block;
-    font-weight: 600;
-  }
-
-  small {
-    color: var(--muted-text);
-  }
-}
-
-.categoria-bar {
-  margin-top: 0.6rem;
-  height: 0.5rem;
-  border-radius: 999px;
-  background: var(--chart-track);
-  overflow: hidden;
-}
-
-.categoria-bar-fill {
-  height: 100%;
-  border-radius: inherit;
-}
-
-.categoria-chart {
-  margin-top: 0.6rem;
-  height: 70px;
-  position: relative;
-}
-
-.categoria-chart canvas {
-  height: 100% !important;
-}
-
-.categoria-percent {
-  position: absolute;
-  inset: 0;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--text);
+.categorias-chart {
+  margin-top: 0.8rem;
+  height: 260px;
 }
 
 .chart-block {

--- a/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.scss
+++ b/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.scss
@@ -55,9 +55,11 @@
 
 .legend {
   display: flex;
+  justify-content: center;
   flex-wrap: wrap;
   gap: 0.6rem;
   font-size: 0.75rem;
+  margin-top: 0.5rem;
 }
 
 .legend-item {

--- a/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.ts
+++ b/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.ts
@@ -130,13 +130,17 @@ export class DashboardResumoCategoriasComponent {
         datalabels: {
           color: this.cssVar('--text'),
           font: { weight: 600 },
+          display: (context) => {
+            const value = Number(context.dataset.data[context.dataIndex] ?? 0);
+            return (value / totalDespesas) * 100 >= 5;
+          },
           formatter: (value) => {
             const percent = (Number(value) / totalDespesas) * 100;
-            return percent >= 1 ? `${Math.round(percent)}%` : '';
+            return `${Math.round(percent)}%`;
           },
         },
       },
-      cutout: '68%',
+      cutout: '48%',
     };
   });
 

--- a/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.ts
+++ b/frontend/src/app/features/dashboard/components/dashboard-resumo-categorias/dashboard-resumo-categorias.component.ts
@@ -1,22 +1,20 @@
 import { DOCUMENT } from '@angular/common';
 import { Component, computed, inject, input, signal } from '@angular/core';
-import { DecimalPipe } from '@angular/common';
 import { Chart, ChartData, ChartOptions } from 'chart.js';
 import { NgChartsModule } from 'ng2-charts';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 import {
   CategoriaResponse,
-  ClassificacaoCategoria,
   CLASSIFICACAO_LABELS,
 } from '../../../../core/models/categoria.models';
 import { PeriodoFinanceiro } from '../../../../core/models/periodo-financeiro.models';
 import { TransacaoResponse } from '../../../../core/models/transacao.models';
-import { CurrencyBRLPipe } from '../../../../shared/pipes/currency-brl.pipe';
-import { formatDate } from '../../../../shared/utils/format.util';
 import { ThemeService } from '../../../../core/services/theme.service';
+import { currencyTooltipLabel } from '../../../../shared/utils/chart-tooltip.util';
+import { formatDate } from '../../../../shared/utils/format.util';
 import {
-  buildCategoriaChartData,
+  buildCategoriasDistribuicaoChartData,
   buildCategoriasLegenda,
   buildClassificacaoChartData,
   buildColorMap,
@@ -31,7 +29,7 @@ import {
 
 @Component({
   selector: 'app-dashboard-resumo-categorias',
-  imports: [CurrencyBRLPipe, DecimalPipe, NgChartsModule],
+  imports: [NgChartsModule],
   templateUrl: './dashboard-resumo-categorias.component.html',
   styleUrl: './dashboard-resumo-categorias.component.scss',
 })
@@ -50,7 +48,6 @@ export class DashboardResumoCategoriasComponent {
   readonly classificacaoLabels = CLASSIFICACAO_LABELS;
   readonly barChartType: 'bar' = 'bar';
   readonly doughnutChartType: 'doughnut' = 'doughnut';
-  readonly categoriaChartType: 'doughnut' = 'doughnut';
 
   readonly despesas = computed(() => filterDespesas(this.transacoes()));
 
@@ -70,7 +67,10 @@ export class DashboardResumoCategoriasComponent {
       maintainAspectRatio: false,
       plugins: {
         legend: { display: false },
-        tooltip: { enabled: true },
+        tooltip: {
+          enabled: true,
+          callbacks: { label: currencyTooltipLabel },
+        },
         datalabels: { display: false },
       },
       scales: {
@@ -97,6 +97,10 @@ export class DashboardResumoCategoriasComponent {
       maintainAspectRatio: false,
       plugins: {
         legend: { position: 'bottom', labels: { color: this.cssVar('--muted-text') } },
+        tooltip: {
+          enabled: true,
+          callbacks: { label: currencyTooltipLabel },
+        },
         datalabels: {
           color: this.cssVar('--text'),
           font: { weight: 600 },
@@ -110,18 +114,29 @@ export class DashboardResumoCategoriasComponent {
     };
   });
 
-  readonly categoriaChartOptions = computed<ChartOptions<'doughnut'>>(() => {
+  readonly categoriasChartOptions = computed<ChartOptions<'doughnut'>>(() => {
     this.theme.effectiveTheme();
+    const totalDespesas = Math.max(1, sumValores(this.despesas()));
 
     return {
       responsive: true,
       maintainAspectRatio: false,
       plugins: {
-        legend: { display: false },
-        tooltip: { enabled: false },
-        datalabels: { display: false },
+        legend: { position: 'bottom', labels: { color: this.cssVar('--muted-text') } },
+        tooltip: {
+          enabled: true,
+          callbacks: { label: currencyTooltipLabel },
+        },
+        datalabels: {
+          color: this.cssVar('--text'),
+          font: { weight: 600 },
+          formatter: (value) => {
+            const percent = (Number(value) / totalDespesas) * 100;
+            return percent >= 1 ? `${Math.round(percent)}%` : '';
+          },
+        },
       },
-      cutout: '70%',
+      cutout: '68%',
     };
   });
 
@@ -150,15 +165,15 @@ export class DashboardResumoCategoriasComponent {
     );
   });
 
+  readonly categoriasChartData = computed<ChartData<'doughnut'>>(() => {
+    this.theme.effectiveTheme();
+    return buildCategoriasDistribuicaoChartData(this.resumoCategorias());
+  });
+
   readonly resumoClassificacao = computed<ClassificacaoResumo[]>(() => buildResumoClassificacao(this.despesas()));
 
   toggle(): void {
     this.aberto.update((value) => !value);
-  }
-
-  categoriaChartData(item: CategoriaResumo): ChartData<'doughnut'> {
-    this.theme.effectiveTheme();
-    return buildCategoriaChartData(item.total, this.totalReceitas(), item.color, this.cssVar('--chart-track'));
   }
 
   formatDate = formatDate;

--- a/frontend/src/app/features/dashboard/utils/dashboard-resumo.util.spec.ts
+++ b/frontend/src/app/features/dashboard/utils/dashboard-resumo.util.spec.ts
@@ -1,4 +1,5 @@
 import {
+  buildCategoriasDistribuicaoChartData,
   buildDailyChartData,
   buildResumoCategorias,
   buildResumoClassificacao,
@@ -42,6 +43,17 @@ describe('dashboard-resumo.util', () => {
 
     expect(resumoCategorias.map((item) => item.nome)).toEqual(['Moradia', 'Mercado']);
     expect(resumoClassificacao[0]).toMatchObject({ classificacao: 'ESSENCIAL', total: 150 });
+  });
+
+  it('monta doughnut único de distribuição por categoria', () => {
+    const despesas = filterDespesas(transacoes);
+    const receitas = sumValores(transacoes.filter((tx) => tx.tipoMovimentacao === 'RECEITA'));
+    const saldo = receitas - sumValores(despesas);
+    const resumo = buildResumoCategorias(despesas, saldo, receitas, (key) => `color-${key}`);
+    const chart = buildCategoriasDistribuicaoChartData(resumo);
+
+    expect(chart.labels).toEqual(['Moradia', 'Mercado']);
+    expect(chart.datasets[0].data).toEqual([100, 50]);
   });
 
   it('monta dados do gráfico diário', () => {

--- a/frontend/src/app/features/dashboard/utils/dashboard-resumo.util.ts
+++ b/frontend/src/app/features/dashboard/utils/dashboard-resumo.util.ts
@@ -140,21 +140,16 @@ export function buildClassificacaoChartData(
   };
 }
 
-export function buildCategoriaChartData(
-  totalCategoria: number,
-  totalReceitas: number,
-  itemColor: string,
-  trackColor: string
+/** Doughnut único com distribuição dos totais por categoria. */
+export function buildCategoriasDistribuicaoChartData(
+  resumoCategorias: CategoriaResumo[]
 ): ChartData<'doughnut'> {
-  const receitas = Math.max(1, totalReceitas);
-  const restante = Math.max(0, receitas - totalCategoria);
-
   return {
-    labels: ['Gasto', 'Restante'],
+    labels: resumoCategorias.map((item) => item.nome),
     datasets: [
       {
-        data: [totalCategoria, restante],
-        backgroundColor: [itemColor, trackColor],
+        data: resumoCategorias.map((item) => item.total),
+        backgroundColor: resumoCategorias.map((item) => item.color),
         borderWidth: 0,
       },
     ],

--- a/frontend/src/app/features/dashboard/utils/dashboard-resumo.util.ts
+++ b/frontend/src/app/features/dashboard/utils/dashboard-resumo.util.ts
@@ -140,7 +140,6 @@ export function buildClassificacaoChartData(
   };
 }
 
-/** Doughnut único com distribuição dos totais por categoria. */
 export function buildCategoriasDistribuicaoChartData(
   resumoCategorias: CategoriaResumo[]
 ): ChartData<'doughnut'> {

--- a/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.ts
+++ b/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.ts
@@ -20,6 +20,7 @@ import { ThemeService } from '../../../../core/services/theme.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { CurrencyBRLPipe } from '../../../../shared/pipes/currency-brl.pipe';
 import { ConfirmDialogService } from '../../../../shared/services/confirm-dialog.service';
+import { currencyTooltipLabel } from '../../../../shared/utils/chart-tooltip.util';
 import { mapApiError } from '../../../../shared/utils/error-message.util';
 import { formatMonthYear, toIsoDate } from '../../../../shared/utils/format.util';
 import { PlanejamentoModalComponent } from '../../components/planejamento-modal/planejamento-modal.component';
@@ -93,6 +94,10 @@ export class PlanejamentosPageComponent implements OnInit {
       cutout: '62%',
       plugins: {
         legend: { position: 'bottom', labels: { color: this.cssVar('--muted-text') } },
+        tooltip: {
+          enabled: true,
+          callbacks: { label: currencyTooltipLabel },
+        },
         datalabels: {
           color: this.cssVar('--text'),
           font: { weight: 600 },

--- a/frontend/src/app/shared/utils/chart-tooltip.util.ts
+++ b/frontend/src/app/shared/utils/chart-tooltip.util.ts
@@ -1,0 +1,25 @@
+import { ChartType, TooltipItem } from 'chart.js';
+
+import { formatMoney } from './format.util';
+
+/** Label de tooltip Chart.js com valor em R$ (pt-BR). */
+export function currencyTooltipLabel(context: TooltipItem<ChartType>): string {
+  const label = context.dataset.label || context.label || '';
+  const value = resolveTooltipValue(context);
+  const prefix = label ? `${label}: ` : '';
+  return `${prefix}${formatMoney(value)}`;
+}
+
+function resolveTooltipValue(context: TooltipItem<ChartType>): number {
+  const parsed = context.parsed;
+
+  if (typeof parsed === 'number') {
+    return parsed;
+  }
+
+  if (parsed && typeof parsed === 'object' && 'y' in parsed) {
+    return Number((parsed as { y: number }).y) || 0;
+  }
+
+  return Number(context.raw) || 0;
+}

--- a/frontend/src/app/shared/utils/chart-tooltip.util.ts
+++ b/frontend/src/app/shared/utils/chart-tooltip.util.ts
@@ -2,23 +2,23 @@ import { ChartType, TooltipItem } from 'chart.js';
 
 import { formatMoney } from './format.util';
 
-/** Label de tooltip Chart.js com valor em R$ (pt-BR). */
-export function currencyTooltipLabel(context: TooltipItem<ChartType>): string {
-  const label = context.dataset.label || context.label || '';
+export function currencyTooltipLabel<TType extends ChartType>(context: TooltipItem<TType>): string {
+  const dataset = context.dataset as { label?: string };
+  const label = dataset.label || context.label || '';
   const value = resolveTooltipValue(context);
   const prefix = label ? `${label}: ` : '';
   return `${prefix}${formatMoney(value)}`;
 }
 
-function resolveTooltipValue(context: TooltipItem<ChartType>): number {
-  const parsed = context.parsed;
+function resolveTooltipValue<TType extends ChartType>(context: TooltipItem<TType>): number {
+  const parsed = context.parsed as number | { y?: number } | null | undefined;
 
   if (typeof parsed === 'number') {
     return parsed;
   }
 
   if (parsed && typeof parsed === 'object' && 'y' in parsed) {
-    return Number((parsed as { y: number }).y) || 0;
+    return Number(parsed.y) || 0;
   }
 
   return Number(context.raw) || 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objetivo
Fecha a issue #18: unificar o resumo por categoria em um único doughnut e formatar valores em R$ nos tooltips dos gráficos.

## Mudanças
- Substitui os doughnuts individuais por categoria por um único gráfico de distribuição (`buildCategoriasDistribuicaoChartData`)
- Mantém os gráficos “Gastos por dia” e “Gastos por classificação”
- Adiciona `currencyTooltipLabel` compartilhado e aplica formatação BRL nos tooltips do dashboard (resumo + comparativo) e da página de planejamentos
- Usa Chart.js (já adotado no projeto), sem ECharts

## Como validar
1. Abrir o Dashboard → Resumo por categoria → Mostrar
2. Confirmar um único doughnut de gastos por categoria
3. Passar o mouse nos gráficos e ver valores no formato `R$ X.XXX,XX`
4. Confirmar que “Gastos por dia” e “Gastos por classificação” permanecem

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6c24-7b93-7a52-a5a5-dd24cb1c4822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6c24-7b93-7a52-a5a5-dd24cb1c4822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

