### PR TITLE
feat(planejamentos): período, filtros, sync e exclusão em lote (#53)

### DIFF
--- a/backend/src/main/java/br/com/budgetflow/features/planejamentos/api/PlanejamentoController.java
+++ b/backend/src/main/java/br/com/budgetflow/features/planejamentos/api/PlanejamentoController.java
@@ -1,8 +1,11 @@
 package br.com.budgetflow.features.planejamentos.api;
 
 import java.net.URI;
-import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import br.com.budgetflow.features.planejamentos.criteria.PlanejamentoFilterCriteria;
 import br.com.budgetflow.features.planejamentos.dto.PlanejamentoRequestDTO;
 import br.com.budgetflow.features.planejamentos.dto.PlanejamentoResponseDTO;
 import br.com.budgetflow.features.planejamentos.dto.SincronizacaoPlanejamentosResponseDTO;
@@ -33,8 +37,11 @@ public class PlanejamentoController {
     }
 
     @GetMapping
-    public ResponseEntity<List<PlanejamentoResponseDTO>> findAll(@RequestParam Long periodoId) {
-        return ResponseEntity.ok(planejamentoService.findAll(periodoId));
+    public ResponseEntity<Page<PlanejamentoResponseDTO>> findAll(
+            @Valid PlanejamentoFilterCriteria criteria,
+            @PageableDefault(sort = {"createdAt", "id"}, direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(planejamentoService.findAll(criteria, pageable));
     }
 
     @PostMapping
@@ -49,6 +56,12 @@ public class PlanejamentoController {
             @Valid @RequestBody PlanejamentoRequestDTO request
     ) {
         return ResponseEntity.ok(planejamentoService.update(id, request));
+    }
+
+    @DeleteMapping("/periodo/{periodoId}")
+    public ResponseEntity<Void> deleteAllByPeriodo(@PathVariable Long periodoId) {
+        planejamentoService.deleteAllByPeriodo(periodoId);
+        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/br/com/budgetflow/features/planejamentos/criteria/PlanejamentoFilterCriteria.java
+++ b/backend/src/main/java/br/com/budgetflow/features/planejamentos/criteria/PlanejamentoFilterCriteria.java
@@ -1,0 +1,47 @@
+package br.com.budgetflow.features.planejamentos.criteria;
+
+import br.com.budgetflow.common.enums.ClassificacaoCategoria;
+import br.com.budgetflow.common.enums.NaturezaFinanceira;
+import jakarta.validation.constraints.NotNull;
+
+public class PlanejamentoFilterCriteria {
+
+    @NotNull(message = "O período é obrigatório")
+    private Long periodoId;
+
+    private String query;
+    private NaturezaFinanceira tipoMovimentacao;
+    private ClassificacaoCategoria classificacaoCategoria;
+
+    public Long getPeriodoId() {
+        return periodoId;
+    }
+
+    public void setPeriodoId(Long periodoId) {
+        this.periodoId = periodoId;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public NaturezaFinanceira getTipoMovimentacao() {
+        return tipoMovimentacao;
+    }
+
+    public void setTipoMovimentacao(NaturezaFinanceira tipoMovimentacao) {
+        this.tipoMovimentacao = tipoMovimentacao;
+    }
+
+    public ClassificacaoCategoria getClassificacaoCategoria() {
+        return classificacaoCategoria;
+    }
+
+    public void setClassificacaoCategoria(ClassificacaoCategoria classificacaoCategoria) {
+        this.classificacaoCategoria = classificacaoCategoria;
+    }
+}

--- a/backend/src/main/java/br/com/budgetflow/features/planejamentos/dto/PlanejamentoRequestDTO.java
+++ b/backend/src/main/java/br/com/budgetflow/features/planejamentos/dto/PlanejamentoRequestDTO.java
@@ -24,6 +24,8 @@ public record PlanejamentoRequestDTO(
         BigDecimal valor,
 
         @NotNull(message = "O tipo da movimentação é obrigatório")
-        NaturezaFinanceira tipoMovimentacao
+        NaturezaFinanceira tipoMovimentacao,
+
+        Long transacaoRecorrenteId
 ) {
 }

--- a/backend/src/main/java/br/com/budgetflow/features/planejamentos/repository/PlanejamentoRepository.java
+++ b/backend/src/main/java/br/com/budgetflow/features/planejamentos/repository/PlanejamentoRepository.java
@@ -7,12 +7,14 @@ import java.util.Set;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import br.com.budgetflow.features.planejamentos.domain.Planejamento;
 
-public interface PlanejamentoRepository extends JpaRepository<Planejamento, Long> {
+public interface PlanejamentoRepository extends JpaRepository<Planejamento, Long>, JpaSpecificationExecutor<Planejamento> {
 
     @EntityGraph(attributePaths = {"user", "categoria", "periodo"})
     List<Planejamento> findAllByPeriodoIdAndUserIdAndExcluidoFalseOrderByCreatedAtDescIdDesc(Long periodoId, Long userId);
@@ -35,6 +37,14 @@ public interface PlanejamentoRepository extends JpaRepository<Planejamento, Long
     boolean existsByCategoriaIdAndUserIdAndExcluidoFalse(Long categoriaId, Long userId);
 
     boolean existsByPeriodoIdAndUserIdAndExcluidoFalse(Long periodoId, Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from Planejamento p
+            where p.periodo.id = :periodoId
+              and p.user.id = :userId
+            """)
+    int deleteAllByPeriodoIdAndUserId(@Param("periodoId") Long periodoId, @Param("userId") Long userId);
 
     @Query("""
             select distinct p.categoria.id

--- a/backend/src/main/java/br/com/budgetflow/features/planejamentos/repository/specification/PlanejamentoSpecification.java
+++ b/backend/src/main/java/br/com/budgetflow/features/planejamentos/repository/specification/PlanejamentoSpecification.java
@@ -1,0 +1,81 @@
+package br.com.budgetflow.features.planejamentos.repository.specification;
+
+import br.com.budgetflow.common.enums.ClassificacaoCategoria;
+import br.com.budgetflow.common.enums.NaturezaFinanceira;
+import br.com.budgetflow.features.planejamentos.criteria.PlanejamentoFilterCriteria;
+import br.com.budgetflow.features.planejamentos.domain.Planejamento;
+import jakarta.persistence.criteria.JoinType;
+import org.springframework.data.jpa.domain.Specification;
+
+public final class PlanejamentoSpecification {
+
+    private PlanejamentoSpecification() {
+    }
+
+    public static Specification<Planejamento> createSpecification(PlanejamentoFilterCriteria criteria, Long userId) {
+        return Specification
+                .where(fetchAssociations())
+                .and(hasUserId(userId))
+                .and(notExcluido())
+                .and(hasPeriodoId(criteria.getPeriodoId()))
+                .and(hasTipoMovimentacao(criteria.getTipoMovimentacao()))
+                .and(hasClassificacaoCategoria(criteria.getClassificacaoCategoria()))
+                .and(hasSearchTerm(criteria.getQuery()));
+    }
+
+    private static Specification<Planejamento> fetchAssociations() {
+        return (root, query, cb) -> {
+            if (!isCountQuery(query)) {
+                root.fetch("categoria", JoinType.LEFT);
+                root.fetch("periodo", JoinType.LEFT);
+                root.fetch("user", JoinType.LEFT);
+                query.distinct(true);
+            }
+            return null;
+        };
+    }
+
+    private static boolean isCountQuery(jakarta.persistence.criteria.CriteriaQuery<?> query) {
+        Class<?> resultType = query.getResultType();
+        return Long.class.equals(resultType) || long.class.equals(resultType);
+    }
+
+    private static Specification<Planejamento> hasUserId(Long userId) {
+        return (root, query, cb) -> cb.equal(root.get("user").get("id"), userId);
+    }
+
+    private static Specification<Planejamento> notExcluido() {
+        return (root, query, cb) -> cb.isFalse(root.get("excluido"));
+    }
+
+    private static Specification<Planejamento> hasPeriodoId(Long periodoId) {
+        return (root, query, cb) -> periodoId == null
+                ? null
+                : cb.equal(root.get("periodo").get("id"), periodoId);
+    }
+
+    private static Specification<Planejamento> hasTipoMovimentacao(NaturezaFinanceira tipoMovimentacao) {
+        return (root, query, cb) -> tipoMovimentacao == null
+                ? null
+                : cb.equal(root.get("tipoMovimentacao"), tipoMovimentacao);
+    }
+
+    private static Specification<Planejamento> hasClassificacaoCategoria(ClassificacaoCategoria classificacao) {
+        return (root, query, cb) -> classificacao == null
+                ? null
+                : cb.equal(root.join("categoria", JoinType.INNER).get("classificacao"), classificacao);
+    }
+
+    private static Specification<Planejamento> hasSearchTerm(String searchTerm) {
+        return (root, query, cb) -> {
+            if (searchTerm == null || searchTerm.isBlank()) {
+                return null;
+            }
+            String normalized = "%" + searchTerm.trim().toLowerCase() + "%";
+            return cb.or(
+                    cb.like(cb.lower(root.get("descricao")), normalized),
+                    cb.like(cb.lower(root.join("categoria", JoinType.INNER).get("nome")), normalized)
+            );
+        };
+    }
+}

--- a/backend/src/main/java/br/com/budgetflow/features/planejamentos/service/GeracaoPlanejamentosRecorrentesService.java
+++ b/backend/src/main/java/br/com/budgetflow/features/planejamentos/service/GeracaoPlanejamentosRecorrentesService.java
@@ -1,0 +1,96 @@
+package br.com.budgetflow.features.planejamentos.service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import br.com.budgetflow.features.movimentacoes.domain.TransacaoRecorrente;
+import br.com.budgetflow.features.movimentacoes.repository.TransacaoRecorrenteRepository;
+import br.com.budgetflow.features.movimentacoes.service.support.RecorrenciaUtils;
+import br.com.budgetflow.features.periodos.domain.PeriodoFinanceiro;
+import br.com.budgetflow.features.planejamentos.domain.Planejamento;
+import br.com.budgetflow.features.planejamentos.dto.SincronizacaoPlanejamentosResponseDTO;
+import br.com.budgetflow.features.planejamentos.repository.PlanejamentoRepository;
+import br.com.budgetflow.features.planejamentos.service.support.PlanejamentoChaveSincronizacaoUtils;
+
+@Service
+public class GeracaoPlanejamentosRecorrentesService {
+
+    private final TransacaoRecorrenteRepository recorrenteRepository;
+    private final PlanejamentoRepository planejamentoRepository;
+
+    public GeracaoPlanejamentosRecorrentesService(
+            TransacaoRecorrenteRepository recorrenteRepository,
+            PlanejamentoRepository planejamentoRepository
+    ) {
+        this.recorrenteRepository = recorrenteRepository;
+        this.planejamentoRepository = planejamentoRepository;
+    }
+
+    @Transactional
+    public SincronizacaoPlanejamentosResponseDTO sincronizar(PeriodoFinanceiro periodo, Long userId) {
+        List<Planejamento> novos = new ArrayList<>();
+        Set<String> chavesSincronizadas = new HashSet<>(
+                planejamentoRepository.findChavesSincronizacaoByPeriodoIdAndUserId(periodo.getId(), userId)
+        );
+        int semValor = 0;
+
+        for (TransacaoRecorrente recorrente : recorrenteRepository.findAllByUserId(userId)) {
+            if (recorrente.getValor() == null) {
+                semValor++;
+                continue;
+            }
+            gerarOcorrenciasDoPeriodo(recorrente, periodo, userId, chavesSincronizadas, novos);
+        }
+
+        planejamentoRepository.saveAll(novos);
+        String mensagem = "Sincronização concluída: " + novos.size()
+                + " planejamentos gerados e " + semValor + " recorrências sem valor.";
+        return new SincronizacaoPlanejamentosResponseDTO(novos.size(), semValor, mensagem);
+    }
+
+    private void gerarOcorrenciasDoPeriodo(
+            TransacaoRecorrente recorrente,
+            PeriodoFinanceiro periodo,
+            Long userId,
+            Set<String> chavesSincronizadas,
+            List<Planejamento> novos
+    ) {
+        long indice = 0;
+        while (recorrente.getTotalParcelas() == null || indice < recorrente.getTotalParcelas()) {
+            LocalDate data = RecorrenciaUtils.calcularDataOcorrencia(
+                    recorrente.getDataInicio(),
+                    recorrente.getFrequencia(),
+                    indice
+            );
+
+            if (recorrente.getDataFim() != null && data.isAfter(recorrente.getDataFim())) {
+                break;
+            }
+            if (data.isAfter(periodo.getDataFim())) {
+                break;
+            }
+
+            if (!data.isBefore(periodo.getDataInicio())) {
+                String chave = PlanejamentoChaveSincronizacaoUtils.build(userId, recorrente.getId(), data);
+                if (chavesSincronizadas.add(chave)) {
+                    Planejamento planejamento = new Planejamento();
+                    planejamento.setUser(recorrente.getUser());
+                    planejamento.setPeriodo(periodo);
+                    planejamento.setCategoria(recorrente.getCategoria());
+                    planejamento.setDescricao(recorrente.getDescricao());
+                    planejamento.setValor(recorrente.getValor());
+                    planejamento.setTipoMovimentacao(recorrente.getTipoMovimentacao());
+                    planejamento.setChaveSincronizacao(chave);
+                    novos.add(planejamento);
+                }
+            }
+            indice++;
+        }
+    }
+}

--- a/backend/src/main/java/br/com/budgetflow/features/planejamentos/service/PlanejamentoRecorrenteVinculoService.java
+++ b/backend/src/main/java/br/com/budgetflow/features/planejamentos/service/PlanejamentoRecorrenteVinculoService.java
@@ -1,0 +1,80 @@
+package br.com.budgetflow.features.planejamentos.service;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import br.com.budgetflow.common.exceptions.BusinessRuleException;
+import br.com.budgetflow.common.exceptions.ResourceNotFoundException;
+import br.com.budgetflow.features.movimentacoes.domain.TransacaoRecorrente;
+import br.com.budgetflow.features.movimentacoes.repository.TransacaoRecorrenteRepository;
+import br.com.budgetflow.features.movimentacoes.service.support.RecorrenciaUtils;
+import br.com.budgetflow.features.periodos.domain.PeriodoFinanceiro;
+import br.com.budgetflow.features.planejamentos.repository.PlanejamentoRepository;
+import br.com.budgetflow.features.planejamentos.service.support.PlanejamentoChaveSincronizacaoUtils;
+
+@Service
+public class PlanejamentoRecorrenteVinculoService {
+
+    private final TransacaoRecorrenteRepository recorrenteRepository;
+    private final PlanejamentoRepository planejamentoRepository;
+
+    public PlanejamentoRecorrenteVinculoService(
+            TransacaoRecorrenteRepository recorrenteRepository,
+            PlanejamentoRepository planejamentoRepository
+    ) {
+        this.recorrenteRepository = recorrenteRepository;
+        this.planejamentoRepository = planejamentoRepository;
+    }
+
+    public String resolverChaveSincronizacao(Long recorrenteId, PeriodoFinanceiro periodo, Long userId) {
+        TransacaoRecorrente recorrente = recorrenteRepository.findByIdAndUserId(recorrenteId, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Transação recorrente não encontrada"));
+
+        Set<String> chavesExistentes = planejamentoRepository.findChavesSincronizacaoByPeriodoIdAndUserId(
+                periodo.getId(),
+                userId
+        );
+        LocalDate dataOcorrencia = findFirstAvailableOccurrence(recorrente, periodo, userId, chavesExistentes);
+        if (dataOcorrencia == null) {
+            throw new BusinessRuleException(
+                    "Todas as ocorrências desta recorrência já foram lançadas neste período"
+            );
+        }
+
+        return PlanejamentoChaveSincronizacaoUtils.build(userId, recorrente.getId(), dataOcorrencia);
+    }
+
+    private LocalDate findFirstAvailableOccurrence(
+            TransacaoRecorrente recorrente,
+            PeriodoFinanceiro periodo,
+            Long userId,
+            Set<String> chavesExistentes
+    ) {
+        long indice = 0;
+        while (recorrente.getTotalParcelas() == null || indice < recorrente.getTotalParcelas()) {
+            LocalDate data = RecorrenciaUtils.calcularDataOcorrencia(
+                    recorrente.getDataInicio(),
+                    recorrente.getFrequencia(),
+                    indice
+            );
+
+            if (recorrente.getDataFim() != null && data.isAfter(recorrente.getDataFim())) {
+                break;
+            }
+            if (data.isAfter(periodo.getDataFim())) {
+                break;
+            }
+
+            if (!data.isBefore(periodo.getDataInicio())) {
+                String chave = PlanejamentoChaveSincronizacaoUtils.build(userId, recorrente.getId(), data);
+                if (!chavesExistentes.contains(chave)) {
+                    return data;
+                }
+            }
+            indice++;
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/br/com/budgetflow/features/planejamentos/service/PlanejamentoService.java
+++ b/backend/src/main/java/br/com/budgetflow/features/planejamentos/service/PlanejamentoService.java
@@ -1,15 +1,5 @@
 package br.com.budgetflow.features.planejamentos.service;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.HexFormat;
-import java.util.List;
-import java.util.Set;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -20,9 +10,6 @@ import br.com.budgetflow.common.exceptions.BusinessRuleException;
 import br.com.budgetflow.common.exceptions.ResourceNotFoundException;
 import br.com.budgetflow.features.categorias.domain.Categoria;
 import br.com.budgetflow.features.categorias.repository.CategoriaRepository;
-import br.com.budgetflow.features.movimentacoes.domain.TransacaoRecorrente;
-import br.com.budgetflow.features.movimentacoes.repository.TransacaoRecorrenteRepository;
-import br.com.budgetflow.features.movimentacoes.service.support.RecorrenciaUtils;
 import br.com.budgetflow.features.periodos.domain.PeriodoFinanceiro;
 import br.com.budgetflow.features.periodos.service.PeriodoFinanceiroService;
 import br.com.budgetflow.features.planejamentos.criteria.PlanejamentoFilterCriteria;
@@ -41,26 +28,29 @@ import br.com.budgetflow.security.SecurityUtils;
 public class PlanejamentoService {
 
     private final PlanejamentoRepository planejamentoRepository;
-    private final TransacaoRecorrenteRepository recorrenteRepository;
     private final CategoriaRepository categoriaRepository;
     private final PeriodoFinanceiroService periodoFinanceiroService;
     private final UserService userService;
     private final PlanejamentoMapper planejamentoMapper;
+    private final PlanejamentoRecorrenteVinculoService recorrenteVinculoService;
+    private final GeracaoPlanejamentosRecorrentesService geracaoPlanejamentosRecorrentesService;
 
     public PlanejamentoService(
             PlanejamentoRepository planejamentoRepository,
-            TransacaoRecorrenteRepository recorrenteRepository,
             CategoriaRepository categoriaRepository,
             PeriodoFinanceiroService periodoFinanceiroService,
             UserService userService,
-            PlanejamentoMapper planejamentoMapper
+            PlanejamentoMapper planejamentoMapper,
+            PlanejamentoRecorrenteVinculoService recorrenteVinculoService,
+            GeracaoPlanejamentosRecorrentesService geracaoPlanejamentosRecorrentesService
     ) {
         this.planejamentoRepository = planejamentoRepository;
-        this.recorrenteRepository = recorrenteRepository;
         this.categoriaRepository = categoriaRepository;
         this.periodoFinanceiroService = periodoFinanceiroService;
         this.userService = userService;
         this.planejamentoMapper = planejamentoMapper;
+        this.recorrenteVinculoService = recorrenteVinculoService;
+        this.geracaoPlanejamentosRecorrentesService = geracaoPlanejamentosRecorrentesService;
     }
 
     @Transactional(readOnly = true)
@@ -68,10 +58,10 @@ public class PlanejamentoService {
         Long userId = SecurityUtils.currentUserId();
         PeriodoFinanceiro periodo = periodoFinanceiroService.resolvePeriodoToTransacao(criteria.getPeriodoId(), userId);
 
-        PlanejamentoFilterCriteria effective = criteria;
-        effective.setPeriodoId(periodo.getId());
+        PlanejamentoFilterCriteria planejamentos = criteria;
+        planejamentos.setPeriodoId(periodo.getId());
 
-        Specification<Planejamento> specification = PlanejamentoSpecification.createSpecification(effective, userId);
+        Specification<Planejamento> specification = PlanejamentoSpecification.createSpecification(planejamentos, userId);
         return planejamentoRepository.findAll(specification, pageable).map(planejamentoMapper::toResponseDTO);
     }
 
@@ -88,7 +78,12 @@ public class PlanejamentoService {
         fillEditableFields(planejamento, request, categoria);
 
         if (request.transacaoRecorrenteId() != null) {
-            applyRecorrenteSyncKey(planejamento, request.transacaoRecorrenteId(), periodo, userId);
+            String chaveSincronizacao = recorrenteVinculoService.resolverChaveSincronizacao(
+                    request.transacaoRecorrenteId(),
+                    periodo,
+                    userId
+            );
+            planejamento.setChaveSincronizacao(chaveSincronizacao);
         }
 
         return planejamentoMapper.toResponseDTO(planejamentoRepository.save(planejamento));
@@ -132,119 +127,7 @@ public class PlanejamentoService {
     public SincronizacaoPlanejamentosResponseDTO sincronizarRecorrentes(Long periodoId) {
         Long userId = SecurityUtils.currentUserId();
         PeriodoFinanceiro periodo = periodoFinanceiroService.resolvePeriodoToTransacao(periodoId, userId);
-        List<Planejamento> novos = new ArrayList<>();
-        Set<String> chavesSincronizadas = new HashSet<>(
-                planejamentoRepository.findChavesSincronizacaoByPeriodoIdAndUserId(periodo.getId(), userId)
-        );
-        int semValor = 0;
-
-        for (TransacaoRecorrente recorrente : recorrenteRepository.findAllByUserId(userId)) {
-            if (recorrente.getValor() == null) {
-                semValor++;
-                continue;
-            }
-            gerarOcorrenciasDoPeriodo(recorrente, periodo, userId, chavesSincronizadas, novos);
-        }
-
-        planejamentoRepository.saveAll(novos);
-        String mensagem = "Sincronização concluída: " + novos.size()
-                + " planejamentos gerados e " + semValor + " recorrências sem valor.";
-        return new SincronizacaoPlanejamentosResponseDTO(novos.size(), semValor, mensagem);
-    }
-
-    private void applyRecorrenteSyncKey(
-            Planejamento planejamento,
-            Long recorrenteId,
-            PeriodoFinanceiro periodo,
-            Long userId
-    ) {
-        TransacaoRecorrente recorrente = recorrenteRepository.findByIdAndUserId(recorrenteId, userId)
-                .orElseThrow(() -> new ResourceNotFoundException("Transação recorrente não encontrada"));
-
-        Set<String> chavesExistentes = planejamentoRepository.findChavesSincronizacaoByPeriodoIdAndUserId(
-                periodo.getId(),
-                userId
-        );
-        LocalDate dataOcorrencia = findFirstAvailableOccurrence(recorrente, periodo, userId, chavesExistentes);
-        if (dataOcorrencia == null) {
-            throw new BusinessRuleException(
-                    "Todas as ocorrências desta recorrência já foram lançadas neste período"
-            );
-        }
-
-        planejamento.setChaveSincronizacao(buildSyncKey(userId, recorrente.getId(), dataOcorrencia));
-    }
-
-    private LocalDate findFirstAvailableOccurrence(
-            TransacaoRecorrente recorrente,
-            PeriodoFinanceiro periodo,
-            Long userId,
-            Set<String> chavesExistentes
-    ) {
-        long indice = 0;
-        while (recorrente.getTotalParcelas() == null || indice < recorrente.getTotalParcelas()) {
-            LocalDate data = RecorrenciaUtils.calcularDataOcorrencia(
-                    recorrente.getDataInicio(),
-                    recorrente.getFrequencia(),
-                    indice
-            );
-
-            if (recorrente.getDataFim() != null && data.isAfter(recorrente.getDataFim())) {
-                break;
-            }
-            if (data.isAfter(periodo.getDataFim())) {
-                break;
-            }
-
-            if (!data.isBefore(periodo.getDataInicio())) {
-                String chave = buildSyncKey(userId, recorrente.getId(), data);
-                if (!chavesExistentes.contains(chave)) {
-                    return data;
-                }
-            }
-            indice++;
-        }
-        return null;
-    }
-
-    private void gerarOcorrenciasDoPeriodo(
-            TransacaoRecorrente recorrente,
-            PeriodoFinanceiro periodo,
-            Long userId,
-            Set<String> chavesSincronizadas,
-            List<Planejamento> novos
-    ) {
-        long indice = 0;
-        while (recorrente.getTotalParcelas() == null || indice < recorrente.getTotalParcelas()) {
-            LocalDate data = RecorrenciaUtils.calcularDataOcorrencia(
-                    recorrente.getDataInicio(),
-                    recorrente.getFrequencia(),
-                    indice
-            );
-
-            if (recorrente.getDataFim() != null && data.isAfter(recorrente.getDataFim())) {
-                break;
-            }
-            if (data.isAfter(periodo.getDataFim())) {
-                break;
-            }
-
-            if (!data.isBefore(periodo.getDataInicio())) {
-                String chave = buildSyncKey(userId, recorrente.getId(), data);
-                if (chavesSincronizadas.add(chave)) {
-                    Planejamento planejamento = new Planejamento();
-                    planejamento.setUser(recorrente.getUser());
-                    planejamento.setPeriodo(periodo);
-                    planejamento.setCategoria(recorrente.getCategoria());
-                    planejamento.setDescricao(recorrente.getDescricao());
-                    planejamento.setValor(recorrente.getValor());
-                    planejamento.setTipoMovimentacao(recorrente.getTipoMovimentacao());
-                    planejamento.setChaveSincronizacao(chave);
-                    novos.add(planejamento);
-                }
-            }
-            indice++;
-        }
+        return geracaoPlanejamentosRecorrentesService.sincronizar(periodo, userId);
     }
 
     private Categoria resolveCategoria(PlanejamentoRequestDTO request, Long userId) {
@@ -271,15 +154,5 @@ public class PlanejamentoService {
     private Planejamento findEntity(Long id, Long userId) {
         return planejamentoRepository.findByIdAndUserIdAndExcluidoFalse(id, userId)
                 .orElseThrow(() -> new ResourceNotFoundException("Planejamento não encontrado"));
-    }
-
-    private String buildSyncKey(Long userId, Long recorrenteId, LocalDate data) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            String source = userId + ":" + recorrenteId + ":" + data;
-            return HexFormat.of().formatHex(digest.digest(source.getBytes(StandardCharsets.UTF_8)));
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("SHA-256 indisponível", ex);
-        }
     }
 }

--- a/backend/src/main/java/br/com/budgetflow/features/planejamentos/service/PlanejamentoService.java
+++ b/backend/src/main/java/br/com/budgetflow/features/planejamentos/service/PlanejamentoService.java
@@ -10,6 +10,9 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,12 +25,14 @@ import br.com.budgetflow.features.movimentacoes.repository.TransacaoRecorrenteRe
 import br.com.budgetflow.features.movimentacoes.service.support.RecorrenciaUtils;
 import br.com.budgetflow.features.periodos.domain.PeriodoFinanceiro;
 import br.com.budgetflow.features.periodos.service.PeriodoFinanceiroService;
+import br.com.budgetflow.features.planejamentos.criteria.PlanejamentoFilterCriteria;
 import br.com.budgetflow.features.planejamentos.domain.Planejamento;
 import br.com.budgetflow.features.planejamentos.dto.PlanejamentoRequestDTO;
 import br.com.budgetflow.features.planejamentos.dto.PlanejamentoResponseDTO;
 import br.com.budgetflow.features.planejamentos.dto.SincronizacaoPlanejamentosResponseDTO;
 import br.com.budgetflow.features.planejamentos.mapper.PlanejamentoMapper;
 import br.com.budgetflow.features.planejamentos.repository.PlanejamentoRepository;
+import br.com.budgetflow.features.planejamentos.repository.specification.PlanejamentoSpecification;
 import br.com.budgetflow.features.users.domain.User;
 import br.com.budgetflow.features.users.service.UserService;
 import br.com.budgetflow.security.SecurityUtils;
@@ -59,14 +64,15 @@ public class PlanejamentoService {
     }
 
     @Transactional(readOnly = true)
-    public List<PlanejamentoResponseDTO> findAll(Long periodoId) {
+    public Page<PlanejamentoResponseDTO> findAll(PlanejamentoFilterCriteria criteria, Pageable pageable) {
         Long userId = SecurityUtils.currentUserId();
-        PeriodoFinanceiro periodo = periodoFinanceiroService.resolvePeriodoToTransacao(periodoId, userId);
-        return planejamentoRepository
-                .findAllByPeriodoIdAndUserIdAndExcluidoFalseOrderByCreatedAtDescIdDesc(periodo.getId(), userId)
-                .stream()
-                .map(planejamentoMapper::toResponseDTO)
-                .toList();
+        PeriodoFinanceiro periodo = periodoFinanceiroService.resolvePeriodoToTransacao(criteria.getPeriodoId(), userId);
+
+        PlanejamentoFilterCriteria effective = criteria;
+        effective.setPeriodoId(periodo.getId());
+
+        Specification<Planejamento> specification = PlanejamentoSpecification.createSpecification(effective, userId);
+        return planejamentoRepository.findAll(specification, pageable).map(planejamentoMapper::toResponseDTO);
     }
 
     @Transactional
@@ -80,6 +86,10 @@ public class PlanejamentoService {
         planejamento.setUser(user);
         planejamento.setPeriodo(periodo);
         fillEditableFields(planejamento, request, categoria);
+
+        if (request.transacaoRecorrenteId() != null) {
+            applyRecorrenteSyncKey(planejamento, request.transacaoRecorrenteId(), periodo, userId);
+        }
 
         return planejamentoMapper.toResponseDTO(planejamentoRepository.save(planejamento));
     }
@@ -112,6 +122,13 @@ public class PlanejamentoService {
     }
 
     @Transactional
+    public void deleteAllByPeriodo(Long periodoId) {
+        Long userId = SecurityUtils.currentUserId();
+        PeriodoFinanceiro periodo = periodoFinanceiroService.resolvePeriodoToTransacao(periodoId, userId);
+        planejamentoRepository.deleteAllByPeriodoIdAndUserId(periodo.getId(), userId);
+    }
+
+    @Transactional
     public SincronizacaoPlanejamentosResponseDTO sincronizarRecorrentes(Long periodoId) {
         Long userId = SecurityUtils.currentUserId();
         PeriodoFinanceiro periodo = periodoFinanceiroService.resolvePeriodoToTransacao(periodoId, userId);
@@ -133,6 +150,61 @@ public class PlanejamentoService {
         String mensagem = "Sincronização concluída: " + novos.size()
                 + " planejamentos gerados e " + semValor + " recorrências sem valor.";
         return new SincronizacaoPlanejamentosResponseDTO(novos.size(), semValor, mensagem);
+    }
+
+    private void applyRecorrenteSyncKey(
+            Planejamento planejamento,
+            Long recorrenteId,
+            PeriodoFinanceiro periodo,
+            Long userId
+    ) {
+        TransacaoRecorrente recorrente = recorrenteRepository.findByIdAndUserId(recorrenteId, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Transação recorrente não encontrada"));
+
+        Set<String> chavesExistentes = planejamentoRepository.findChavesSincronizacaoByPeriodoIdAndUserId(
+                periodo.getId(),
+                userId
+        );
+        LocalDate dataOcorrencia = findFirstAvailableOccurrence(recorrente, periodo, userId, chavesExistentes);
+        if (dataOcorrencia == null) {
+            throw new BusinessRuleException(
+                    "Todas as ocorrências desta recorrência já foram lançadas neste período"
+            );
+        }
+
+        planejamento.setChaveSincronizacao(buildSyncKey(userId, recorrente.getId(), dataOcorrencia));
+    }
+
+    private LocalDate findFirstAvailableOccurrence(
+            TransacaoRecorrente recorrente,
+            PeriodoFinanceiro periodo,
+            Long userId,
+            Set<String> chavesExistentes
+    ) {
+        long indice = 0;
+        while (recorrente.getTotalParcelas() == null || indice < recorrente.getTotalParcelas()) {
+            LocalDate data = RecorrenciaUtils.calcularDataOcorrencia(
+                    recorrente.getDataInicio(),
+                    recorrente.getFrequencia(),
+                    indice
+            );
+
+            if (recorrente.getDataFim() != null && data.isAfter(recorrente.getDataFim())) {
+                break;
+            }
+            if (data.isAfter(periodo.getDataFim())) {
+                break;
+            }
+
+            if (!data.isBefore(periodo.getDataInicio())) {
+                String chave = buildSyncKey(userId, recorrente.getId(), data);
+                if (!chavesExistentes.contains(chave)) {
+                    return data;
+                }
+            }
+            indice++;
+        }
+        return null;
     }
 
     private void gerarOcorrenciasDoPeriodo(

--- a/backend/src/main/java/br/com/budgetflow/features/planejamentos/service/support/PlanejamentoChaveSincronizacaoUtils.java
+++ b/backend/src/main/java/br/com/budgetflow/features/planejamentos/service/support/PlanejamentoChaveSincronizacaoUtils.java
@@ -1,0 +1,23 @@
+package br.com.budgetflow.features.planejamentos.service.support;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
+import java.util.HexFormat;
+
+public final class PlanejamentoChaveSincronizacaoUtils {
+
+    private PlanejamentoChaveSincronizacaoUtils() {
+    }
+
+    public static String build(Long userId, Long recorrenteId, LocalDate data) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            String source = userId + ":" + recorrenteId + ":" + data;
+            return HexFormat.of().formatHex(digest.digest(source.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 indisponível", ex);
+        }
+    }
+}

--- a/backend/src/test/java/br/com/budgetflow/features/planejamentos/service/GeracaoPlanejamentosRecorrentesServiceTest.java
+++ b/backend/src/test/java/br/com/budgetflow/features/planejamentos/service/GeracaoPlanejamentosRecorrentesServiceTest.java
@@ -1,0 +1,100 @@
+package br.com.budgetflow.features.planejamentos.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import br.com.budgetflow.common.enums.Frequencia;
+import br.com.budgetflow.common.enums.NaturezaFinanceira;
+import br.com.budgetflow.features.movimentacoes.domain.TransacaoRecorrente;
+import br.com.budgetflow.features.movimentacoes.repository.TransacaoRecorrenteRepository;
+import br.com.budgetflow.features.periodos.domain.PeriodoFinanceiro;
+import br.com.budgetflow.features.planejamentos.domain.Planejamento;
+import br.com.budgetflow.features.planejamentos.repository.PlanejamentoRepository;
+import br.com.budgetflow.features.users.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GeracaoPlanejamentosRecorrentesServiceTest {
+
+    @Mock
+    private TransacaoRecorrenteRepository recorrenteRepository;
+    @Mock
+    private PlanejamentoRepository planejamentoRepository;
+
+    private GeracaoPlanejamentosRecorrentesService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new GeracaoPlanejamentosRecorrentesService(recorrenteRepository, planejamentoRepository);
+    }
+
+    @Test
+    void sincronizacaoGeraOcorrenciasIdempotentesEIgnoraRecorrenciaSemValor() {
+        User user = mock(User.class);
+        PeriodoFinanceiro periodo = mock(PeriodoFinanceiro.class);
+        when(periodo.getUser()).thenReturn(user);
+        when(periodo.getId()).thenReturn(10L);
+        when(periodo.getDataInicio()).thenReturn(LocalDate.of(2026, 6, 1));
+        when(periodo.getDataFim()).thenReturn(LocalDate.of(2026, 6, 30));
+
+        TransacaoRecorrente mensal = recorrente(20L, user, LocalDate.of(2026, 5, 10), BigDecimal.TEN);
+        TransacaoRecorrente semValor = recorrente(21L, user, LocalDate.of(2026, 6, 15), null);
+        when(recorrenteRepository.findAllByUserId(1L)).thenReturn(List.of(mensal, semValor));
+
+        Set<String> chavesPersistidas = new HashSet<>();
+        when(planejamentoRepository.findChavesSincronizacaoByPeriodoIdAndUserId(10L, 1L))
+                .thenAnswer(invocation -> new HashSet<>(chavesPersistidas));
+        when(planejamentoRepository.saveAll(any())).thenAnswer(invocation -> {
+            List<Planejamento> items = invocation.getArgument(0);
+            items.forEach(item -> chavesPersistidas.add(item.getChaveSincronizacao()));
+            return items;
+        });
+
+        var primeira = service.sincronizar(periodo, 1L);
+        var segunda = service.sincronizar(periodo, 1L);
+
+        assertEquals(1, primeira.planejamentosGerados());
+        assertEquals(1, primeira.recorrenciasSemValor());
+        assertEquals(0, segunda.planejamentosGerados());
+
+        ArgumentCaptor<Iterable<Planejamento>> captor = ArgumentCaptor.forClass(Iterable.class);
+        verify(planejamentoRepository, times(2)).saveAll(captor.capture());
+        verify(planejamentoRepository, times(2))
+                .findChavesSincronizacaoByPeriodoIdAndUserId(10L, 1L);
+        Planejamento gerado = captor.getAllValues().getFirst().iterator().next();
+        assertTrue(gerado.isSincronizado());
+    }
+
+    private TransacaoRecorrente recorrente(Long id, User user, LocalDate inicio, BigDecimal valor) {
+        TransacaoRecorrente recorrente = mock(TransacaoRecorrente.class);
+        when(recorrente.getId()).thenReturn(id);
+        when(recorrente.getUser()).thenReturn(user);
+        when(recorrente.getDataInicio()).thenReturn(inicio);
+        when(recorrente.getFrequencia()).thenReturn(Frequencia.MENSAL);
+        when(recorrente.getTotalParcelas()).thenReturn(null);
+        when(recorrente.getValor()).thenReturn(valor);
+        when(recorrente.getDescricao()).thenReturn("Recorrente");
+        when(recorrente.getTipoMovimentacao()).thenReturn(NaturezaFinanceira.DESPESA);
+        return recorrente;
+    }
+}

--- a/backend/src/test/java/br/com/budgetflow/features/planejamentos/service/PlanejamentoServiceTest.java
+++ b/backend/src/test/java/br/com/budgetflow/features/planejamentos/service/PlanejamentoServiceTest.java
@@ -1,26 +1,17 @@
 package br.com.budgetflow.features.planejamentos.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -28,17 +19,11 @@ import org.mockito.quality.Strictness;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import br.com.budgetflow.common.enums.Frequencia;
-import br.com.budgetflow.common.enums.NaturezaFinanceira;
 import br.com.budgetflow.features.categorias.repository.CategoriaRepository;
-import br.com.budgetflow.features.movimentacoes.domain.TransacaoRecorrente;
-import br.com.budgetflow.features.movimentacoes.repository.TransacaoRecorrenteRepository;
-import br.com.budgetflow.features.periodos.domain.PeriodoFinanceiro;
 import br.com.budgetflow.features.periodos.service.PeriodoFinanceiroService;
 import br.com.budgetflow.features.planejamentos.domain.Planejamento;
 import br.com.budgetflow.features.planejamentos.mapper.PlanejamentoMapper;
 import br.com.budgetflow.features.planejamentos.repository.PlanejamentoRepository;
-import br.com.budgetflow.features.users.domain.User;
 import br.com.budgetflow.features.users.service.UserService;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,8 +33,6 @@ class PlanejamentoServiceTest {
     @Mock
     private PlanejamentoRepository planejamentoRepository;
     @Mock
-    private TransacaoRecorrenteRepository recorrenteRepository;
-    @Mock
     private CategoriaRepository categoriaRepository;
     @Mock
     private PeriodoFinanceiroService periodoFinanceiroService;
@@ -57,6 +40,10 @@ class PlanejamentoServiceTest {
     private UserService userService;
     @Mock
     private PlanejamentoMapper planejamentoMapper;
+    @Mock
+    private PlanejamentoRecorrenteVinculoService recorrenteVinculoService;
+    @Mock
+    private GeracaoPlanejamentosRecorrentesService geracaoPlanejamentosRecorrentesService;
 
     private PlanejamentoService service;
 
@@ -67,55 +54,18 @@ class PlanejamentoServiceTest {
         );
         service = new PlanejamentoService(
                 planejamentoRepository,
-                recorrenteRepository,
                 categoriaRepository,
                 periodoFinanceiroService,
                 userService,
-                planejamentoMapper
+                planejamentoMapper,
+                recorrenteVinculoService,
+                geracaoPlanejamentosRecorrentesService
         );
     }
 
     @AfterEach
     void tearDown() {
         SecurityContextHolder.clearContext();
-    }
-
-    @Test
-    void sincronizacaoGeraOcorrenciasIdempotentesEIgnoraRecorrenciaSemValor() {
-        User user = mock(User.class);
-        PeriodoFinanceiro periodo = mock(PeriodoFinanceiro.class);
-        when(periodo.getUser()).thenReturn(user);
-        when(periodo.getId()).thenReturn(10L);
-        when(periodo.getDataInicio()).thenReturn(LocalDate.of(2026, 6, 1));
-        when(periodo.getDataFim()).thenReturn(LocalDate.of(2026, 6, 30));
-        when(periodoFinanceiroService.resolvePeriodoToTransacao(10L, 1L)).thenReturn(periodo);
-
-        TransacaoRecorrente mensal = recorrente(20L, user, LocalDate.of(2026, 5, 10), BigDecimal.TEN);
-        TransacaoRecorrente semValor = recorrente(21L, user, LocalDate.of(2026, 6, 15), null);
-        when(recorrenteRepository.findAllByUserId(1L)).thenReturn(List.of(mensal, semValor));
-
-        Set<String> chavesPersistidas = new HashSet<>();
-        when(planejamentoRepository.findChavesSincronizacaoByPeriodoIdAndUserId(10L, 1L))
-                .thenAnswer(invocation -> new HashSet<>(chavesPersistidas));
-        when(planejamentoRepository.saveAll(any())).thenAnswer(invocation -> {
-            List<Planejamento> items = invocation.getArgument(0);
-            items.forEach(item -> chavesPersistidas.add(item.getChaveSincronizacao()));
-            return items;
-        });
-
-        var primeira = service.sincronizarRecorrentes(10L);
-        var segunda = service.sincronizarRecorrentes(10L);
-
-        assertEquals(1, primeira.planejamentosGerados());
-        assertEquals(1, primeira.recorrenciasSemValor());
-        assertEquals(0, segunda.planejamentosGerados());
-
-        ArgumentCaptor<Iterable<Planejamento>> captor = ArgumentCaptor.forClass(Iterable.class);
-        verify(planejamentoRepository, times(2)).saveAll(captor.capture());
-        verify(planejamentoRepository, times(2))
-                .findChavesSincronizacaoByPeriodoIdAndUserId(10L, 1L);
-        Planejamento gerado = captor.getAllValues().getFirst().iterator().next();
-        assertTrue(gerado.isSincronizado());
     }
 
     @Test
@@ -130,18 +80,5 @@ class PlanejamentoServiceTest {
         assertTrue(planejamento.isExcluido());
         verify(planejamentoRepository).save(planejamento);
         verify(planejamentoRepository, never()).delete(planejamento);
-    }
-
-    private TransacaoRecorrente recorrente(Long id, User user, LocalDate inicio, BigDecimal valor) {
-        TransacaoRecorrente recorrente = mock(TransacaoRecorrente.class);
-        when(recorrente.getId()).thenReturn(id);
-        when(recorrente.getUser()).thenReturn(user);
-        when(recorrente.getDataInicio()).thenReturn(inicio);
-        when(recorrente.getFrequencia()).thenReturn(Frequencia.MENSAL);
-        when(recorrente.getTotalParcelas()).thenReturn(null);
-        when(recorrente.getValor()).thenReturn(valor);
-        when(recorrente.getDescricao()).thenReturn("Recorrente");
-        when(recorrente.getTipoMovimentacao()).thenReturn(NaturezaFinanceira.DESPESA);
-        return recorrente;
     }
 }

--- a/frontend/src/app/core/models/planejamento.models.ts
+++ b/frontend/src/app/core/models/planejamento.models.ts
@@ -1,5 +1,6 @@
 import { ClassificacaoCategoria } from './categoria.models';
 import { NaturezaFinanceira } from './natureza-financeira.models';
+import { PageResponse } from './pagination.models';
 
 export interface PlanejamentoResponse {
   id: number;
@@ -22,6 +23,7 @@ export interface PlanejamentoRequest {
   descricao: string;
   valor: number;
   tipoMovimentacao: NaturezaFinanceira;
+  transacaoRecorrenteId?: number | null;
 }
 
 export interface SincronizacaoPlanejamentosResponse {
@@ -29,3 +31,5 @@ export interface SincronizacaoPlanejamentosResponse {
   recorrenciasSemValor: number;
   mensagem: string;
 }
+
+export type PlanejamentoPageResponse = PageResponse<PlanejamentoResponse>;

--- a/frontend/src/app/core/services/planejamentos-api.service.ts
+++ b/frontend/src/app/core/services/planejamentos-api.service.ts
@@ -3,19 +3,63 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { API_BASE_URL } from '../config/api.config';
+import { ClassificacaoCategoria } from '../models/categoria.models';
+import { NaturezaFinanceira } from '../models/natureza-financeira.models';
+import { PageSize } from '../models/pagination.models';
 import {
+  PlanejamentoPageResponse,
   PlanejamentoRequest,
   PlanejamentoResponse,
   SincronizacaoPlanejamentosResponse,
 } from '../models/planejamento.models';
 
+export interface PlanejamentoListParams {
+  periodoId: number;
+  page?: number;
+  size?: number;
+  query?: string;
+  tipoMovimentacao?: NaturezaFinanceira | '';
+  classificacaoCategoria?: ClassificacaoCategoria | '';
+}
+
 @Injectable({ providedIn: 'root' })
 export class PlanejamentosApiService {
   private readonly http = inject(HttpClient);
 
-  listByPeriodo(periodoId: number): Observable<PlanejamentoResponse[]> {
-    const params = new HttpParams().set('periodoId', String(periodoId));
-    return this.http.get<PlanejamentoResponse[]>(`${API_BASE_URL}/api/planejamentos`, { params });
+  listByPeriodo(periodoId: number, size = PageSize.BULK): Observable<PlanejamentoPageResponse> {
+    const params = new HttpParams({
+      fromObject: {
+        periodoId: String(periodoId),
+        page: '0',
+        size: String(size),
+        sort: 'createdAt,desc',
+      },
+    });
+    return this.http.get<PlanejamentoPageResponse>(`${API_BASE_URL}/api/planejamentos`, { params });
+  }
+
+  listFiltered(filters: PlanejamentoListParams): Observable<PlanejamentoPageResponse> {
+    let params = new HttpParams({
+      fromObject: {
+        periodoId: String(filters.periodoId),
+        page: String(filters.page ?? 0),
+        size: String(filters.size ?? PageSize.DEFAULT),
+        sort: 'createdAt,desc',
+      },
+    });
+
+    const query = filters.query?.trim();
+    if (query) {
+      params = params.set('query', query);
+    }
+    if (filters.tipoMovimentacao) {
+      params = params.set('tipoMovimentacao', filters.tipoMovimentacao);
+    }
+    if (filters.classificacaoCategoria) {
+      params = params.set('classificacaoCategoria', filters.classificacaoCategoria);
+    }
+
+    return this.http.get<PlanejamentoPageResponse>(`${API_BASE_URL}/api/planejamentos`, { params });
   }
 
   create(payload: PlanejamentoRequest): Observable<PlanejamentoResponse> {
@@ -28,6 +72,10 @@ export class PlanejamentosApiService {
 
   delete(id: number): Observable<void> {
     return this.http.delete<void>(`${API_BASE_URL}/api/planejamentos/${id}`);
+  }
+
+  deleteAllByPeriodo(periodoId: number): Observable<void> {
+    return this.http.delete<void>(`${API_BASE_URL}/api/planejamentos/periodo/${periodoId}`);
   }
 
   sincronizarRecorrentes(periodoId: number): Observable<SincronizacaoPlanejamentosResponse> {

--- a/frontend/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.ts
+++ b/frontend/src/app/features/dashboard/pages/dashboard-page/dashboard-page.component.ts
@@ -206,7 +206,7 @@ export class DashboardPageComponent implements OnInit {
       .subscribe({
         next: ({ transacoes, planejamentos }) => {
           this.transacoes.set(transacoes.content);
-          this.planejamentos.set(planejamentos);
+          this.planejamentos.set(planejamentos.content);
           this.loadingResumo.set(false);
         },
         error: (err) => {

--- a/frontend/src/app/features/planejamentos/components/planejamento-modal/planejamento-modal.component.html
+++ b/frontend/src/app/features/planejamentos/components/planejamento-modal/planejamento-modal.component.html
@@ -10,15 +10,17 @@
     }
 
     <form [formGroup]="form" (ngSubmit)="submit()" class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-12" novalidate>
-      <label class="bf-label md:col-span-12">
-        Transação recorrente (opcional)
-        <select class="bf-input" formControlName="transacaoRecorrenteId" (change)="onRecorrenteChange($any($event.target).value)">
-          <option value="">Manual</option>
-          @for (recorrente of recorrentes(); track recorrente.id) {
-            <option [value]="recorrente.id">{{ recorrenteLabel(recorrente) }}</option>
-          }
-        </select>
-      </label>
+      @if (!editingId()) {
+        <label class="bf-label md:col-span-12">
+          Transação recorrente (opcional)
+          <select class="bf-input" formControlName="transacaoRecorrenteId" (change)="onRecorrenteChange($any($event.target).value)">
+            <option value="">Manual</option>
+            @for (recorrente of recorrentesDisponiveis(); track recorrente.id) {
+              <option [value]="recorrente.id">{{ recorrenteLabel(recorrente) }}</option>
+            }
+          </select>
+        </label>
+      }
 
       <label class="bf-label md:col-span-6">
         Tipo de movimentação

--- a/frontend/src/app/features/planejamentos/components/planejamento-modal/planejamento-modal.component.ts
+++ b/frontend/src/app/features/planejamentos/components/planejamento-modal/planejamento-modal.component.ts
@@ -38,6 +38,7 @@ export class PlanejamentoModalComponent implements OnInit {
 
   readonly categorias = input.required<CategoriaResponse[]>();
   readonly recorrentes = input.required<TransacaoRecorrenteResponse[]>();
+  readonly planejamentos = input.required<PlanejamentoResponse[]>();
   readonly selectedPeriodo = input.required<PeriodoFinanceiro>();
   readonly editingPlanejamento = input<PlanejamentoResponse | null>(null);
 
@@ -55,6 +56,15 @@ export class PlanejamentoModalComponent implements OnInit {
   readonly tipoMovimentacaoSelecionado = signal<'' | NaturezaFinanceira>('');
   readonly categoriaModalOpen = signal(false);
   readonly categoriasLocais = signal<CategoriaResponse[]>([]);
+
+  readonly recorrentesDisponiveis = computed(() => {
+    const descricoesLancadas = new Set(
+      this.planejamentos().map((item) => item.descricao.trim().toLowerCase())
+    );
+    return this.recorrentes().filter(
+      (recorrente) => !descricoesLancadas.has(recorrente.descricao.trim().toLowerCase())
+    );
+  });
 
   readonly form = this.formBuilder.nonNullable.group({
     transacaoRecorrenteId: [''],
@@ -131,7 +141,7 @@ export class PlanejamentoModalComponent implements OnInit {
   }
 
   onRecorrenteChange(rawId: string): void {
-    const recorrente = this.recorrentes().find((item) => item.id === Number(rawId));
+    const recorrente = this.recorrentesDisponiveis().find((item) => item.id === Number(rawId));
     if (!recorrente) {
       return;
     }
@@ -161,12 +171,14 @@ export class PlanejamentoModalComponent implements OnInit {
     }
 
     const raw = this.form.getRawValue();
+    const recorrenteId = raw.transacaoRecorrenteId ? Number(raw.transacaoRecorrenteId) : null;
     const payload = {
       categoriaId: Number(raw.categoriaId),
       periodoId: this.selectedPeriodo().id,
       descricao: raw.descricao.trim(),
       valor: parseCurrencyInput(raw.valor) ?? 0,
       tipoMovimentacao: raw.tipoMovimentacao as NaturezaFinanceira,
+      transacaoRecorrenteId: this.editingId() ? null : recorrenteId,
     };
     const editingId = this.editingId();
     const request$ = editingId

--- a/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.html
+++ b/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.html
@@ -10,149 +10,274 @@
           [disabled]="!selectedPeriodo() || syncing()">
           {{ syncing() ? 'Sincronizando...' : 'Sincronizar recorrentes' }}
         </button>
-        <label class="periodo-field grid gap-1">
-          Período selecionado
-          <select [value]="selectedPeriodoId() ?? ''" [disabled]="periodos().length === 0"
-            (change)="onPeriodoChange($any($event.target).value)">
-            @for (periodo of periodos(); track periodo.id) {
-            <option [value]="periodo.id">{{ formatPeriodo(periodo) }}</option>
-            }
-          </select>
-        </label>
+        <div class="periodo-selector">
+          @if (periodos().length > 0) {
+            <label class="periodo-field grid gap-1" for="periodoSelectPlanejamentos">
+              Período selecionado
+              <select
+                id="periodoSelectPlanejamentos"
+                [value]="selectedPeriodoId() ?? ''"
+                [disabled]="loadingPeriodos()"
+                (change)="onPeriodoChange($any($event.target).value)"
+              >
+                @for (periodo of periodos(); track periodo.id) {
+                  <option [value]="periodo.id">{{ formatPeriodo(periodo) }}</option>
+                }
+              </select>
+            </label>
+            <button
+              type="button"
+              class="btn-periodo-add"
+              (click)="openPeriodoModal()"
+              title="Criar novo período"
+              aria-label="Criar novo período"
+            >
+              +
+            </button>
+          } @else if (!loadingPeriodos()) {
+            <button type="button" class="btn-create periodo-add" (click)="openPeriodoModal()">
+              Criar período
+            </button>
+          }
+        </div>
       </div>
     </header>
 
     @if (errorMessage()) {
-    <p class="error">{{ errorMessage() }}</p>
+      <p class="error">{{ errorMessage() }}</p>
     }
 
     @if (loading()) {
-    <section class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-3" aria-label="Carregando cards de resumo">
-      @for (item of skeletonCards; track item) {
-      <article class="card">
-        <p class="bf-skeleton-line h-3 w-28"></p>
-        <strong class="bf-skeleton-line mt-3 block h-6 w-36"></strong>
-      </article>
-      }
-    </section>
-    } @else {
-    @if (!selectedPeriodo()) {
-    <p class="muted loading">Não existem períodos financeiros cadastrados.</p>
-    }
-
-    <section class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-3">
-      <article class="card saldo">
-        <p>Saldo previsto</p><strong>{{ saldo() | currencyBRL }}</strong>
-      </article>
-      <article class="card receita">
-        <p>Receitas</p><strong>{{ receitas() | currencyBRL }}</strong>
-      </article>
-      <article class="card despesa">
-        <p>Despesas</p><strong>{{ despesas() | currencyBRL }}</strong>
-      </article>
-    </section>
-
-    @if (planejamentos().length > 0) {
-    <section class="resumo">
-      <div class="resumo-head">
-        <div>
-          <h2>Resumo do planejamento</h2>
-          <p class="muted">Despesas planejadas agrupadas no período.</p>
-        </div>
-        <button type="button" class="btn-toggle" (click)="toggleResumo()">
-          {{ resumoAberto() ? 'Ocultar' : 'Mostrar' }}
-        </button>
-      </div>
-
-      @if (resumoAberto()) {
-      <div class="charts-grid">
-        <article class="chart-block">
-          <div class="chart-head">
-            <h3>Despesas por categoria</h3>
-          </div>
-          @if (categoriaChartData().labels?.length) {
-          <div class="chart"><canvas baseChart [type]="chartType" [data]="categoriaChartData()"
-              [options]="chartOptions()"></canvas></div>
-          } @else {
-          <p class="muted empty">Sem despesas planejadas.</p>
-          }
-        </article>
-        <article class="chart-block">
-          <div class="chart-head">
-            <h3>Despesas por classificação</h3>
-          </div>
-          @if (classificacaoChartData().labels?.length) {
-          <div class="chart"><canvas baseChart [type]="chartType" [data]="classificacaoChartData()"
-              [options]="chartOptions()"></canvas></div>
-          } @else {
-          <p class="muted empty">Sem classificações para exibir.</p>
-          }
-        </article>
-      </div>
-      }
-    </section>
-    }
-
-    <section class="transacoes">
-      <div class="recentes-head">
-        <div>
-          <h2>Lançamentos planejados para o período</h2>
-        </div>
-        <button type="button" class="btn-create" (click)="openCreateModal()" [disabled]="!selectedPeriodo()">
-          Cadastrar planejamento
-        </button>
-      </div>
-      <section class="recentes bf-panel">
-        @if (planejamentos().length === 0 && selectedPeriodo()) {
-        <p class="muted">Nenhum planejamento cadastrado para o período.</p>
-        } @else {
-        <div class="list-header">
-          <div>
-            <h2>Lista de planejamentos financeiros</h2>
-            @if (planejamentos().length > 0) {
-            @if (planejamentos().length === 1) {
-            <small class="muted">{{ planejamentos().length }} planejamento</small>
-            } @else {
-            <small class="muted">{{ planejamentos().length }} planejamentos</small>
-            }
-            }
-          </div>
-        </div>
-        <ul class="mt-4 grid gap-2">
-          @for (item of planejamentos(); track item.id) {
-          <li>
-            <div>
-              <strong>{{ item.descricao }}</strong>
-              <small>
-                {{ item.categoriaNome }}
-                @if (item.sincronizado) { · Sincronizado }
-              </small>
-            </div>
-            <div class="grid w-full justify-items-stretch gap-2 min-[801px]:w-auto min-[801px]:justify-items-end">
-              <span [class.receita]="item.tipoMovimentacao === 'RECEITA'"
-                [class.despesa]="item.tipoMovimentacao === 'DESPESA'">
-                {{ item.tipoMovimentacao === 'DESPESA' ? '-' : '+' }} {{ item.valor | currencyBRL }}
-              </span>
-              <div class="row-buttons">
-                <button type="button" class="btn-inline" (click)="startEdit(item)">Editar</button>
-                <button type="button" class="btn-inline danger" (click)="delete(item)"
-                  [disabled]="deletingId() === item.id">
-                  {{ deletingId() === item.id ? 'Excluindo...' : 'Excluir' }}
-                </button>
-              </div>
-            </div>
-          </li>
-          }
-        </ul>
+      <section class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-3" aria-label="Carregando cards de resumo">
+        @for (item of skeletonCards; track item) {
+          <article class="card">
+            <p class="bf-skeleton-line h-3 w-28"></p>
+            <strong class="bf-skeleton-line mt-3 block h-6 w-36"></strong>
+          </article>
         }
       </section>
-    </section>
+    } @else {
+      @if (!selectedPeriodo()) {
+        <p class="muted loading">Não existem períodos financeiros cadastrados.</p>
+      }
+
+      <section class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-3">
+        <article class="card saldo">
+          <p>Saldo previsto</p><strong>{{ saldo() | currencyBRL }}</strong>
+        </article>
+        <article class="card receita">
+          <p>Receitas</p><strong>{{ receitas() | currencyBRL }}</strong>
+        </article>
+        <article class="card despesa">
+          <p>Despesas</p><strong>{{ despesas() | currencyBRL }}</strong>
+        </article>
+      </section>
+
+      @if (planejamentos().length > 0) {
+        <section class="resumo">
+          <div class="resumo-head">
+            <div>
+              <h2>Resumo do planejamento</h2>
+              <p class="muted">Despesas planejadas agrupadas no período.</p>
+            </div>
+            <button type="button" class="btn-toggle" (click)="toggleResumo()">
+              {{ resumoAberto() ? 'Ocultar' : 'Mostrar' }}
+            </button>
+          </div>
+
+          @if (resumoAberto()) {
+            <div class="charts-grid">
+              <article class="chart-block">
+                <div class="chart-head">
+                  <h3>Despesas por categoria</h3>
+                </div>
+                @if (categoriaChartData().labels?.length) {
+                  <div class="chart">
+                    <canvas baseChart [type]="chartType" [data]="categoriaChartData()" [options]="chartOptions()"></canvas>
+                  </div>
+                } @else {
+                  <p class="muted empty">Sem despesas planejadas.</p>
+                }
+              </article>
+              <article class="chart-block">
+                <div class="chart-head">
+                  <h3>Despesas por classificação</h3>
+                </div>
+                @if (classificacaoChartData().labels?.length) {
+                  <div class="chart">
+                    <canvas baseChart [type]="chartType" [data]="classificacaoChartData()" [options]="chartOptions()"></canvas>
+                  </div>
+                } @else {
+                  <p class="muted empty">Sem classificações para exibir.</p>
+                }
+              </article>
+            </div>
+          }
+        </section>
+      }
+
+      <section class="transacoes">
+        <div class="recentes-head">
+          <div>
+            <h2>Lançamentos planejados para o período</h2>
+          </div>
+          <div class="head-actions">
+            <button type="button" class="btn-icon" (click)="toggleFiltros()" [disabled]="!selectedPeriodo()">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M4 5h16M7 12h10M10 19h4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+              @if (filtrosAbertos()) {
+                <span>Esconder filtros</span>
+              }
+            </button>
+            <button
+              type="button"
+              class="btn-danger"
+              (click)="deleteAll()"
+              [disabled]="!selectedPeriodo() || deletingAll() || planejamentos().length === 0"
+            >
+              {{ deletingAll() ? 'Excluindo...' : 'Excluir todos' }}
+            </button>
+            <button type="button" class="btn-create" (click)="openCreateModal()" [disabled]="!selectedPeriodo()">
+              Cadastrar planejamento
+            </button>
+          </div>
+        </div>
+
+        @if (filtrosAbertos()) {
+          <section class="bf-panel filters-panel">
+            <h2>Filtros</h2>
+            <form [formGroup]="filtersForm" class="mt-4 grid grid-cols-1 items-end gap-3 md:grid-cols-12" novalidate>
+              <label class="bf-label md:col-span-4">
+                Busca
+                <div class="datalist-field">
+                  <input
+                    class="bf-input"
+                    type="text"
+                    list="planejamentos-categorias-list"
+                    formControlName="query"
+                    placeholder="Descrição ou categoria"
+                  />
+                  <datalist id="planejamentos-categorias-list">
+                    @for (nome of categoriasDistinct(); track nome) {
+                      <option [value]="nome"></option>
+                    }
+                  </datalist>
+                </div>
+              </label>
+
+              <label class="bf-label md:col-span-3">
+                Tipo
+                <select class="bf-input" formControlName="tipoMovimentacao">
+                  <option value="">Todos</option>
+                  @for (item of tiposMovimentacao; track item.value) {
+                    <option [value]="item.value">{{ item.label }}</option>
+                  }
+                </select>
+              </label>
+
+              <label class="bf-label md:col-span-3">
+                Classificação
+                <select class="bf-input" formControlName="classificacaoCategoria">
+                  <option value="">Todas</option>
+                  @for (item of classificacoes; track item.value) {
+                    <option [value]="item.value">{{ item.label }}</option>
+                  }
+                </select>
+              </label>
+
+              <div class="flex md:col-span-2 md:justify-end">
+                <button class="btn-secondary w-full md:w-auto" type="button" (click)="clearFilters()">Limpar</button>
+              </div>
+            </form>
+          </section>
+        }
+
+        <section class="recentes bf-panel">
+          @if (listaPlanejamentos().length === 0 && selectedPeriodo()) {
+            <p class="muted">Nenhum planejamento encontrado com os filtros atuais.</p>
+          } @else {
+            <div class="list-header">
+              <div>
+                <h2>Lista de planejamentos financeiros</h2>
+                @if (totalElements() > 0) {
+                  @if (totalElements() === 1) {
+                    <small class="muted">{{ totalElements() }} planejamento</small>
+                  } @else {
+                    <small class="muted">{{ totalElements() }} planejamentos</small>
+                  }
+                }
+              </div>
+            </div>
+            <ul class="mt-4 grid gap-2">
+              @for (item of listaPlanejamentos(); track item.id) {
+                <li>
+                  <div>
+                    <strong>{{ item.descricao }}</strong>
+                    <small>
+                      {{ item.categoriaNome }}
+                      @if (item.sincronizado) { · Sincronizado }
+                    </small>
+                  </div>
+                  <div class="grid w-full justify-items-stretch gap-2 min-[801px]:w-auto min-[801px]:justify-items-end">
+                    <span
+                      [class.receita]="item.tipoMovimentacao === 'RECEITA'"
+                      [class.despesa]="item.tipoMovimentacao === 'DESPESA'"
+                    >
+                      {{ item.tipoMovimentacao === 'DESPESA' ? '-' : '+' }} {{ item.valor | currencyBRL }}
+                    </span>
+                    <div class="row-buttons">
+                      <button type="button" class="btn-inline" (click)="startEdit(item)">Editar</button>
+                      <button
+                        type="button"
+                        class="btn-inline danger"
+                        (click)="delete(item)"
+                        [disabled]="deletingId() === item.id"
+                      >
+                        {{ deletingId() === item.id ? 'Excluindo...' : 'Excluir' }}
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              }
+            </ul>
+
+            @if (totalPages() > 1) {
+              <div class="bf-pagination">
+                <button type="button" class="btn-inline" (click)="goToPreviousPage()" [disabled]="paginaAtual() === 0">
+                  Anterior
+                </button>
+                <span>Página {{ paginaAtual() + 1 }} de {{ totalPages() }}</span>
+                <button
+                  type="button"
+                  class="btn-inline"
+                  (click)="goToNextPage()"
+                  [disabled]="paginaAtual() + 1 >= totalPages()"
+                >
+                  Próxima
+                </button>
+              </div>
+            }
+          }
+        </section>
+      </section>
     }
   </div>
 </main>
 
 @if (modalOpen() && selectedPeriodo(); as periodo) {
-<app-planejamento-modal [categorias]="categorias()" [recorrentes]="recorrentes()" [selectedPeriodo]="periodo"
-  [editingPlanejamento]="editingPlanejamento()" (saved)="onSaved()" (closed)="closeModal()"
-  (categoriasChanged)="onCategoriasChanged()" />
+  <app-planejamento-modal
+    [categorias]="categorias()"
+    [recorrentes]="recorrentes()"
+    [planejamentos]="planejamentos()"
+    [selectedPeriodo]="periodo"
+    [editingPlanejamento]="editingPlanejamento()"
+    (saved)="onSaved()"
+    (closed)="closeModal()"
+    (categoriasChanged)="onCategoriasChanged()"
+  />
+}
+
+@if (periodoModalOpen()) {
+  <app-periodo-financeiro-modal (saved)="onPeriodoSaved($event)" (closed)="closePeriodoModal()" />
 }

--- a/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.html
+++ b/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.html
@@ -21,7 +21,7 @@
                 (change)="onPeriodoChange($any($event.target).value)"
               >
                 @for (periodo of periodos(); track periodo.id) {
-                  <option [value]="periodo.id">{{ formatPeriodo(periodo) }}</option>
+                  <option [value]="periodo.id" [selected]="periodo.id === selectedPeriodoId()">{{ formatPeriodo(periodo) }}</option>
                 }
               </select>
             </label>
@@ -130,14 +130,14 @@
                 <span>Esconder filtros</span>
               }
             </button>
-            <button
+            <!-- <button
               type="button"
               class="btn-danger"
               (click)="deleteAll()"
               [disabled]="!selectedPeriodo() || deletingAll() || planejamentos().length === 0"
             >
               {{ deletingAll() ? 'Excluindo...' : 'Excluir todos' }}
-            </button>
+            </button> -->
             <button type="button" class="btn-create" (click)="openCreateModal()" [disabled]="!selectedPeriodo()">
               Cadastrar planejamento
             </button>
@@ -197,7 +197,7 @@
           @if (listaPlanejamentos().length === 0 && selectedPeriodo()) {
             <p class="muted">Nenhum planejamento encontrado com os filtros atuais.</p>
           } @else {
-            <div class="list-header">
+            <div class="list-header flex justify-between items-center">
               <div>
                 <h2>Lista de planejamentos financeiros</h2>
                 @if (totalElements() > 0) {
@@ -207,6 +207,16 @@
                     <small class="muted">{{ totalElements() }} planejamentos</small>
                   }
                 }
+              </div>
+              <div>
+                <button
+                type="button"
+                class="btn-danger"
+                (click)="deleteAll()"
+                [disabled]="!selectedPeriodo() || deletingAll() || planejamentos().length === 0"
+              >
+                {{ deletingAll() ? 'Excluindo...' : 'Excluir todos' }}
+              </button>
               </div>
             </div>
             <ul class="mt-4 grid gap-2">

--- a/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.scss
+++ b/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.scss
@@ -56,8 +56,36 @@
 .periodo-field {
   min-width: 0;
   width: min(100%, 28rem);
+  flex: 1;
   font-size: 0.8rem;
   color: var(--muted-text);
+}
+
+.periodo-selector {
+  display: flex;
+  align-items: end;
+  gap: 0.5rem;
+  min-width: 0;
+  width: min(100%, 28rem);
+}
+
+.btn-periodo-add {
+  flex-shrink: 0;
+  min-height: var(--control-height);
+  min-width: var(--control-height);
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--control-radius);
+  background: var(--surface-2);
+  color: var(--text);
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.btn-periodo-add:hover {
+  border-color: var(--brand-green);
 }
 
 .periodo-field select {
@@ -158,6 +186,46 @@ span.receita, span.despesa { font-weight: 600; }
   margin-top: 1.2rem;
 }
 
+.head-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid var(--line);
+  background: none;
+  color: var(--muted-text);
+  font-weight: 400;
+  min-height: var(--control-height);
+  padding: var(--control-padding-y) 0.8rem;
+  border-radius: var(--control-radius);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--text);
+    border-color: var(--line-strong);
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
+.filters-panel {
+  margin-top: 1rem;
+}
+
+.datalist-field {
+  position: relative;
+}
+
 .recentes {
   margin-top: 1rem;
   border: 1px solid var(--line);
@@ -218,7 +286,17 @@ span.receita, span.despesa { font-weight: 600; }
 
   .topbar-actions,
   .periodo-field,
+  .periodo-selector,
   .btn-sync-dashboard {
+    width: 100%;
+  }
+
+  .periodo-selector {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .head-actions {
     width: 100%;
   }
 

--- a/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.scss
+++ b/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.scss
@@ -190,8 +190,6 @@ span.receita, span.despesa { font-weight: 600; }
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  flex-wrap: wrap;
-  justify-content: flex-end;
 }
 
 .btn-icon {
@@ -220,6 +218,7 @@ span.receita, span.despesa { font-weight: 600; }
 
 .filters-panel {
   margin-top: 1rem;
+  padding: 1rem;
 }
 
 .datalist-field {
@@ -281,23 +280,29 @@ span.receita, span.despesa { font-weight: 600; }
   .resumo-head,
   .chart-head {
     flex-direction: column;
-    align-items: flex-end;
+    align-items: flex-start;
   }
 
-  .topbar-actions,
+  .topbar-actions {
+    width: 100%;
+  }
+
   .periodo-field,
-  .periodo-selector,
+  .periodo-selector {
+    width: 100%;
+  }
+
   .btn-sync-dashboard {
     width: 100%;
   }
 
-  .periodo-selector {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
   .head-actions {
     width: 100%;
+    justify-content: space-between;
+  }
+
+  .btn-icon {
+    justify-content: center;
   }
 
   .charts-grid {
@@ -318,10 +323,13 @@ span.receita, span.despesa { font-weight: 600; }
   }
 }
 
-/* Mobile: empilha ações; tablet/desktop mantém row */
 @media (max-width: 640px) {
   .topbar-actions {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .periodo-add {
+    width: 100%;
   }
 }

--- a/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.ts
+++ b/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.ts
@@ -1,32 +1,47 @@
 import { DOCUMENT } from '@angular/common';
 import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { Chart, ChartData, ChartOptions } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { NgChartsModule } from 'ng2-charts';
+import { debounceTime, distinctUntilChanged } from 'rxjs';
 
 import {
   CategoriaResponse,
   CLASSIFICACAO_LABELS,
+  CLASSIFICACOES,
+  ClassificacaoCategoria,
 } from '../../../../core/models/categoria.models';
-import { PeriodoFinanceiro } from '../../../../core/models/periodo-financeiro.models';
+import { NaturezaFinanceira } from '../../../../core/models/natureza-financeira.models';
+import { PageSize } from '../../../../core/models/pagination.models';
+import { PeriodoFinanceiro, PeriodoFinanceiroResponse } from '../../../../core/models/periodo-financeiro.models';
 import { PlanejamentoResponse } from '../../../../core/models/planejamento.models';
 import { TransacaoRecorrenteResponse } from '../../../../core/models/transacao-recorrente.models';
+import { TIPOS_MOVIMENTACAO } from '../../../../core/models/transacao.models';
 import { CategoriasApiService } from '../../../../core/services/categorias-api.service';
 import { PeriodosApiService } from '../../../../core/services/periodos-api.service';
 import { PlanejamentosApiService } from '../../../../core/services/planejamentos-api.service';
-import { TransacoesRecorrentesApiService } from '../../../../core/services/transacoes-recorrentes-api.service';
 import { ThemeService } from '../../../../core/services/theme.service';
 import { ToastService } from '../../../../core/services/toast.service';
+import { TransacoesRecorrentesApiService } from '../../../../core/services/transacoes-recorrentes-api.service';
 import { CurrencyBRLPipe } from '../../../../shared/pipes/currency-brl.pipe';
 import { ConfirmDialogService } from '../../../../shared/services/confirm-dialog.service';
 import { mapApiError } from '../../../../shared/utils/error-message.util';
 import { formatMonthYear, toIsoDate } from '../../../../shared/utils/format.util';
+import { isDesktopViewport } from '../../../../shared/utils/viewport.util';
+import { PeriodoFinanceiroModalComponent } from '../../../periodos/components/periodo-financeiro-modal/periodo-financeiro-modal.component';
 import { PlanejamentoModalComponent } from '../../components/planejamento-modal/planejamento-modal.component';
 
 @Component({
   selector: 'app-planejamentos-page',
-  imports: [CurrencyBRLPipe, NgChartsModule, PlanejamentoModalComponent],
+  imports: [
+    CurrencyBRLPipe,
+    NgChartsModule,
+    PlanejamentoModalComponent,
+    PeriodoFinanceiroModalComponent,
+    ReactiveFormsModule,
+  ],
   templateUrl: './planejamentos-page.component.html',
   styleUrl: './planejamentos-page.component.scss',
 })
@@ -35,6 +50,7 @@ export class PlanejamentosPageComponent implements OnInit {
     Chart.register(ChartDataLabels);
   }
 
+  private readonly formBuilder = inject(FormBuilder);
   private readonly categoriasApi = inject(CategoriasApiService);
   private readonly periodosApi = inject(PeriodosApiService);
   private readonly planejamentosApi = inject(PlanejamentosApiService);
@@ -48,18 +64,34 @@ export class PlanejamentosPageComponent implements OnInit {
   readonly periodos = signal<PeriodoFinanceiro[]>([]);
   readonly categorias = signal<CategoriaResponse[]>([]);
   readonly planejamentos = signal<PlanejamentoResponse[]>([]);
+  readonly listaPlanejamentos = signal<PlanejamentoResponse[]>([]);
   readonly resumoAberto = signal(false);
   readonly recorrentes = signal<TransacaoRecorrenteResponse[]>([]);
   readonly selectedPeriodoId = signal<number | null>(null);
   readonly loading = signal(true);
+  readonly loadingPeriodos = signal(true);
   readonly syncing = signal(false);
   readonly deletingId = signal<number | null>(null);
+  readonly deletingAll = signal(false);
   readonly errorMessage = signal('');
   readonly modalOpen = signal(false);
+  readonly periodoModalOpen = signal(false);
   readonly editingPlanejamento = signal<PlanejamentoResponse | null>(null);
+  readonly filtrosAbertos = signal(isDesktopViewport());
+  readonly paginaAtual = signal(0);
+  readonly totalPages = signal(0);
+  readonly totalElements = signal(0);
   readonly classificacaoLabels = CLASSIFICACAO_LABELS;
+  readonly classificacoes = CLASSIFICACOES;
+  readonly tiposMovimentacao = TIPOS_MOVIMENTACAO;
   readonly chartType: 'doughnut' = 'doughnut';
   readonly skeletonCards = [1, 2, 3];
+
+  readonly filtersForm = this.formBuilder.nonNullable.group({
+    query: [''],
+    tipoMovimentacao: ['' as '' | NaturezaFinanceira],
+    classificacaoCategoria: ['' as '' | ClassificacaoCategoria],
+  });
 
   readonly selectedPeriodo = computed(
     () => this.periodos().find((item) => item.id === this.selectedPeriodoId()) ?? null
@@ -69,6 +101,11 @@ export class PlanejamentosPageComponent implements OnInit {
   readonly saldo = computed(() => this.receitas() - this.despesas());
   readonly despesasPlanejadas = computed(() =>
     this.planejamentos().filter((item) => item.tipoMovimentacao === 'DESPESA')
+  );
+  readonly categoriasDistinct = computed(() =>
+    Array.from(new Set(this.planejamentos().map((item) => item.categoriaNome))).sort((a, b) =>
+      a.localeCompare(b)
+    )
   );
 
   readonly categoriaChartData = computed<ChartData<'doughnut'>>(() =>
@@ -109,18 +146,68 @@ export class PlanejamentosPageComponent implements OnInit {
     this.loadCategorias();
     this.loadRecorrentes();
     this.loadPeriodos();
+
+    this.filtersForm.valueChanges
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged((a, b) => JSON.stringify(a) === JSON.stringify(b)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => this.loadLista(0));
   }
 
   onPeriodoChange(value: string): void {
     const id = Number(value);
     if (Number.isFinite(id)) {
       this.selectedPeriodoId.set(id);
-      this.loadPlanejamentos(id);
+      this.reload();
     }
+  }
+
+  openPeriodoModal(): void {
+    this.periodoModalOpen.set(true);
+  }
+
+  closePeriodoModal(): void {
+    this.periodoModalOpen.set(false);
+  }
+
+  onPeriodoSaved(periodo: PeriodoFinanceiroResponse): void {
+    this.closePeriodoModal();
+    this.loadingPeriodos.set(true);
+    this.errorMessage.set('');
+
+    this.periodosApi
+      .listAll()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (page) => {
+          this.periodos.set(page.content);
+          this.loadingPeriodos.set(false);
+          this.selectedPeriodoId.set(periodo.id);
+          this.reload();
+        },
+        error: (err) => {
+          this.errorMessage.set(mapApiError(err));
+          this.loadingPeriodos.set(false);
+        },
+      });
   }
 
   toggleResumo(): void {
     this.resumoAberto.update((aberto) => !aberto);
+  }
+
+  toggleFiltros(): void {
+    this.filtrosAbertos.update((aberto) => !aberto);
+  }
+
+  clearFilters(): void {
+    this.filtersForm.setValue(
+      { query: '', tipoMovimentacao: '', classificacaoCategoria: '' },
+      { emitEvent: false }
+    );
+    this.loadLista(0);
   }
 
   openCreateModal(): void {
@@ -190,28 +277,77 @@ export class PlanejamentosPageComponent implements OnInit {
       });
   }
 
+  async deleteAll(): Promise<void> {
+    const periodo = this.selectedPeriodo();
+    if (!periodo || this.deletingAll()) {
+      return;
+    }
+
+    const confirmed = await this.confirmDialog.confirm(
+      'Essa alteração não pode ser desfeita. Deseja realmente excluir todos os planejamentos deste período?'
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    this.deletingAll.set(true);
+    this.planejamentosApi
+      .deleteAllByPeriodo(periodo.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.deletingAll.set(false);
+          this.toast.show('Todos os planejamentos do período foram excluídos.', 'success');
+          this.reload();
+        },
+        error: (err) => {
+          this.errorMessage.set(mapApiError(err));
+          this.deletingAll.set(false);
+        },
+      });
+  }
+
+  goToPreviousPage(): void {
+    const atual = this.paginaAtual();
+    if (atual > 0) {
+      this.loadLista(atual - 1);
+    }
+  }
+
+  goToNextPage(): void {
+    const atual = this.paginaAtual();
+    if (atual + 1 < this.totalPages()) {
+      this.loadLista(atual + 1);
+    }
+  }
+
   formatPeriodo(periodo: PeriodoFinanceiro): string {
     return formatMonthYear(periodo.mes, periodo.ano);
   }
 
   private loadPeriodos(): void {
     this.loading.set(true);
+    this.loadingPeriodos.set(true);
     this.periodosApi
       .listAll()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response) => {
           this.periodos.set(response.content);
+          this.loadingPeriodos.set(false);
           const periodo = this.findPeriodoAtual(response.content) ?? response.content[0] ?? null;
           this.selectedPeriodoId.set(periodo?.id ?? null);
           if (periodo) {
-            this.loadPlanejamentos(periodo.id);
+            this.reload();
           } else {
+            this.planejamentos.set([]);
+            this.listaPlanejamentos.set([]);
             this.loading.set(false);
           }
         },
         error: (err) => {
           this.errorMessage.set(mapApiError(err));
+          this.loadingPeriodos.set(false);
           this.loading.set(false);
         },
       });
@@ -237,15 +373,24 @@ export class PlanejamentosPageComponent implements OnInit {
       });
   }
 
-  private loadPlanejamentos(periodoId: number): void {
+  private reload(): void {
+    const id = this.selectedPeriodoId();
+    if (!id) {
+      return;
+    }
+    this.loadResumo(id);
+    this.loadLista(0);
+  }
+
+  private loadResumo(periodoId: number): void {
     this.loading.set(true);
     this.errorMessage.set('');
     this.planejamentosApi
-      .listByPeriodo(periodoId)
+      .listByPeriodo(periodoId, PageSize.BULK)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (items) => {
-          this.planejamentos.set(items);
+        next: (page) => {
+          this.planejamentos.set(page.content);
           this.loading.set(false);
         },
         error: (err) => {
@@ -255,11 +400,49 @@ export class PlanejamentosPageComponent implements OnInit {
       });
   }
 
-  private reload(): void {
-    const id = this.selectedPeriodoId();
-    if (id) {
-      this.loadPlanejamentos(id);
+  private loadLista(page = this.paginaAtual()): void {
+    const periodoId = this.selectedPeriodoId();
+    if (!periodoId) {
+      this.listaPlanejamentos.set([]);
+      this.paginaAtual.set(0);
+      this.totalPages.set(0);
+      this.totalElements.set(0);
+      return;
     }
+
+    const filters = this.filtersForm.getRawValue();
+    this.planejamentosApi
+      .listFiltered({
+        periodoId,
+        page,
+        size: PageSize.DEFAULT,
+        query: filters.query,
+        tipoMovimentacao: filters.tipoMovimentacao,
+        classificacaoCategoria: filters.classificacaoCategoria,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          const totalPages = response.page?.totalPages ?? response.totalPages ?? 0;
+          const totalElements = response.page?.totalElements ?? response.totalElements ?? 0;
+
+          if (response.content.length === 0 && totalPages > 0 && this.paginaAtual() >= totalPages) {
+            this.loadLista(totalPages - 1);
+            return;
+          }
+
+          this.listaPlanejamentos.set(response.content);
+          this.paginaAtual.set(response.page?.number ?? response.number ?? 0);
+          this.totalPages.set(totalPages);
+          this.totalElements.set(totalElements);
+        },
+        error: (err) => {
+          this.errorMessage.set(mapApiError(err));
+          this.listaPlanejamentos.set([]);
+          this.totalPages.set(0);
+          this.totalElements.set(0);
+        },
+      });
   }
 
   private sumByType(tipo: 'RECEITA' | 'DESPESA'): number {

--- a/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.ts
+++ b/frontend/src/app/features/planejamentos/pages/planejamentos-page/planejamentos-page.component.ts
@@ -473,8 +473,18 @@ export class PlanejamentosPageComponent implements OnInit {
   }
 
   private findPeriodoAtual(periodos: PeriodoFinanceiro[]): PeriodoFinanceiro | null {
-    const hoje = toIsoDate(new Date());
-    return periodos.find((item) => hoje >= item.dataInicio && hoje <= item.dataFim) ?? null;
+    const now = new Date();
+    const mes = now.getMonth() + 1;
+    const ano = now.getFullYear();
+    const porMesAno = periodos.find((item) => item.mes === mes && item.ano === ano);
+    if (porMesAno) {
+      return porMesAno;
+    }
+
+    const nowIso = toIsoDate(now);
+    return (
+      periodos.find((item) => nowIso >= item.dataInicio && nowIso <= item.dataFim) ?? null
+    );
   }
 
   private cssVar(name: string): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objetivo
Fecha a issue #53: UX da página de planejamentos, sync sem duplicatas e exclusão em lote.

## Mudanças
- Botão criar período igual ao Dashboard (`+` / “Criar período”)
- Filtros (busca descrição/categoria, tipo, classificação) + paginação na lista
- Cards/gráficos continuam com **todos** os itens do período
- Modal oculta recorrências já lançadas (match por descrição)
- Create a partir de recorrente gera a mesma `chaveSincronizacao` do sync
- `DELETE /api/planejamentos/periodo/{periodoId}` com hard-delete e confirmação no frontend
- GET `/api/planejamentos` passa a retornar `Page` (Dashboard atualizado para `.content`)

## Como validar
1. Criar período pelo `+` na página de planejamentos
2. Filtrar/paginar a lista sem alterar o resumo/gráficos do período
3. Após sync, recorrentes já lançadas não aparecem no modal
4. Lançamento manual de recorrente não gera duplicata no sync
5. “Excluir todos” pede confirmação e remove todos os planejamentos do período

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6c24-7b93-7a52-a5a5-dd24cb1c4822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6c24-7b93-7a52-a5a5-dd24cb1c4822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

