### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+BudgetFlow is a personal-finance app: an Angular 21 SPA in `frontend/` and a Spring Boot 4 / Java 21 REST API in `backend/`, backed by PostgreSQL 16. Standard commands are documented in `README.md`; only the non-obvious cloud caveats are captured here.
+
+### Services and how to run them (start these each session; they are NOT in the update script)
+
+The update script only refreshes dependencies. On a fresh VM you must start the infra + services yourself:
+
+1. **PostgreSQL 16** (installed natively, not via Docker for the app): start with
+   `sudo pg_ctlcluster 16 main start`. The `budgetflow` database and the `postgres`/`postgres` credentials already exist in the snapshot. Recreate if missing:
+   `sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"` and
+   `sudo -u postgres psql -c "CREATE DATABASE budgetflow;"`.
+2. **Backend API** (`:8080`) from `backend/`. Do NOT use the default `dev` Docker-Compose Postgres; point Spring at the native DB and disable compose:
+   ```bash
+   cd backend
+   SPRING_PROFILES_ACTIVE=dev SPRING_DOCKER_COMPOSE_ENABLED=false \
+   SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/budgetflow \
+   SPRING_DATASOURCE_USERNAME=postgres SPRING_DATASOURCE_PASSWORD=postgres \
+   JWT_SECRET=dev-only-change-me-with-at-least-32-chars FRONTEND_URL=http://localhost:4200 \
+   ./mvnw spring-boot:run
+   ```
+   Liquibase migrations run automatically on startup.
+3. **Frontend dev server** (`:4200`) from `frontend/`: `npm start`. It proxies `/api`, `/oauth2`, `/login/oauth2` to `127.0.0.1:8080` (see `frontend/proxy.conf.json`).
+
+### Critical gotcha: `frontend/public/app-config.json` points at production
+
+The committed `frontend/public/app-config.json` has `"apiBaseUrl": "https://api.budgetflow.site"`. With that value the SPA calls the **production** API instead of the local backend (registration/login appear to fail locally with "Falha na requisição"). For local dev this file must be `{"apiBaseUrl": ""}` so the app uses the Angular proxy (as documented in `README.md`). Keep this as a local (uncommitted) change so the production frontend config is not altered.
+
+### Email verification is required for password login, and Resend is not configured
+
+Email/password login is blocked until `users.email_verified_at` is set, and no `RESEND_API_KEY` is present, so verification emails are never sent. To unblock a test account after registering, set it directly in the DB:
+`UPDATE users SET email_verified_at = NOW() WHERE email='<email>';`
+Passwords must contain uppercase, lowercase, a digit and a special character (e.g. `SenhaForte123!`). Google OAuth login needs real Google credentials and is optional.
+
+### Tests
+
+- Backend: `cd backend && ./mvnw test` — uses Testcontainers, so the Docker daemon must be running (`sudo dockerd &`). The `postgres:16` image is already pulled in the snapshot. The current user is in the `docker` group but the daemon must be started each session.
+- Frontend: `cd frontend && npx ng test --watch=false` (Vitest). There is no dedicated lint step in the repo.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objetivo

Configurar o ambiente de desenvolvimento do BudgetFlow para Cloud Agents e documentar os passos/caveats não óbvios para rodar a aplicação ponta a ponta.

## O que foi feito

- Instalado PostgreSQL 16 nativo (DB `budgetflow`, `postgres`/`postgres`) e Docker (para os testes do backend com Testcontainers).
- Instaladas dependências: `frontend` (`npm install`) e `backend` (Maven).
- Adicionado `AGENTS.md` com a seção `## Cursor Cloud specific instructions` cobrindo: como subir Postgres/backend/frontend, o gotcha do `frontend/public/app-config.json` apontar para produção, a verificação de email via DB (Resend não configurado) e como rodar os testes.

> Observação: a mudança em `frontend/public/app-config.json` (`apiBaseUrl: ""` para usar o proxy local) é mantida **apenas localmente** (não commitada) para não alterar a config de produção do frontend.

## Serviços verificados

| Serviço | Comando | Status |
|---|---|---|
| Backend (`:8080`) | `./mvnw spring-boot:run` (profile `dev`, compose off) | OK — migrations Liquibase aplicadas |
| Frontend (`:4200`) | `npm start` | OK — proxy p/ backend |
| Testes backend | `./mvnw test` | 20 testes, 0 falhas |
| Testes frontend | `npx ng test --watch=false` | 25 testes passaram |

## Teste E2E (hello-world)

Login com usuário verificado + criação de categoria "Salário" (Receita), persistida no PostgreSQL.

[budgetflow_login_create_category.mp4](https://cursor.com/agents/bc-34b69cb3-1c3c-4b2e-bd4a-56be745f6be2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbudgetflow_login_create_category.mp4)

[Categoria Salário criada](https://cursor.com/agents/bc-34b69cb3-1c3c-4b2e-bd4a-56be745f6be2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcategory_created_salario.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34b69cb3-1c3c-4b2e-bd4a-56be745f6be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34b69cb3-1c3c-4b2e-bd4a-56be745f6be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

